### PR TITLE
Fix flight sim for portal

### DIFF
--- a/main/modes/flight/flight.c
+++ b/main/modes/flight/flight.c
@@ -762,7 +762,6 @@ static void flightUpdate(void* arg __attribute__((unused)), int64_t elapsedUs)
         case FLIGHT_MENU:
         {
             drawMenuLogbook(flight->menu, flight->menuLogbookRenderer, elapsedUs);
-            drawText(&flight->logbook, c542, "rB", 237, 18);
             break;
         }
         case FLIGHT_FREEFLIGHT:

--- a/main/modes/flight/flight.c
+++ b/main/modes/flight/flight.c
@@ -762,7 +762,7 @@ static void flightUpdate(void* arg __attribute__((unused)), int64_t elapsedUs)
         case FLIGHT_MENU:
         {
             drawMenuLogbook(flight->menu, flight->menuLogbookRenderer, elapsedUs);
-            drawText(&flight->logbook, 206, "rB", 237, 18);
+            drawText(&flight->logbook, c542, "rB", 237, 18);
             break;
         }
         case FLIGHT_FREEFLIGHT:

--- a/main/modes/flight/flight.c
+++ b/main/modes/flight/flight.c
@@ -762,7 +762,7 @@ static void flightUpdate(void* arg __attribute__((unused)), int64_t elapsedUs)
         case FLIGHT_MENU:
         {
             drawMenuLogbook(flight->menu, flight->menuLogbookRenderer, elapsedUs);
-            drawText(&flight->logbook, 206, "rB", 237, 1823);
+            drawText(&flight->logbook, 206, "rB", 237, 18);
             break;
         }
         case FLIGHT_FREEFLIGHT:

--- a/main/modes/mainMenu/mainMenu.c
+++ b/main/modes/mainMenu/mainMenu.c
@@ -65,7 +65,7 @@ void addSecretsMenu(void);
 //==============================================================================
 
 // It's good practice to declare immutable strings as const so they get placed in ROM, not RAM
-const char mainMenuName[]                       = "Main Menu";
+const char mainMenuName[]                       = "Main Menu 1.1";
 static const char mainMenuShowSecretsMenuName[] = "ShowOnMenu: ";
 static const char factoryResetName[]            = "Factory Reset";
 static const char confirmResetName[]            = "! Confirm Reset !";


### PR DESCRIPTION
Fix null reference that sometimes happens when entering flight sim mode if you aren't first to the party (only happens about 10% of the time) but if near the portal will happen close to 95+% of the time.

Also, use a new slot for text as to not override what text already was, since the existing swadges squawk out an annoying message all the time.