### PR TITLE
Initial MacOS Support

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -6,7 +6,12 @@ It is strongly recommend that you follow the instructions on this page to set up
 
 It is recommended to use native tools (i.e. Windows programs on Windows), not Windows Subsystem for Linux (WSL) or a virtual machine.
 
-macOS is not officially supported. It is likely possible to build the firmware on macOS, but the emulator requires [rawdraw](https://github.com/cntools/rawdraw), which does not support macOS.
+macOS is not officially supported quite yet. It is likely possible to build the firmware on macOS, and the emulator has limited support on Mac OS, requiring:
+
+- xquartz
+- libxinerama
+
+These can be obtained through [Homebrew](https://brew.sh/). Note that at this time, there is no sound on the macOS builds. When running on macOS, you will need to run the emulator through the xQuartz terminal instead.
 
 Espressif's installation guide notes limitations for the ESP-IDF's path:
 > The installation path of ESP-IDF and ESP-IDF Tools must not be longer than 90 characters.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -85,11 +85,15 @@ Note: Some installs of Python will have py.exe instead of python.exe - If this i
 1. Install [Homebrew](https://brew.sh/)
 2. Run the following command to install all necessary dependencies:
     ```bash
-    brew install xquartz libxinerama clang-format cppcheck wget doxygen
+    brew install xquartz libxinerama pulseaudio clang-format cppcheck wget doxygen
     ```
+3. Before running the simulator on your machine, you need to start pulseaudio like so:
+    ```bash
+    brew services start pulseaudio
+    ```
+    You can stop it by running `brew services start pulseaudio` when you are done.
 
-
-Note that at this time, there is no sound on the macOS builds. When running on macOS, you will need to run the emulator through the xQuartz terminal instead. Building the firmware directly is also not supported fully yet at this time.
+When running on macOS, you will need to run the emulator through the xQuartz terminal instead. Building the firmware directly is also not supported fully yet at this time.
 
 ## Building and Flashing Firmware
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -6,18 +6,6 @@ It is strongly recommend that you follow the instructions on this page to set up
 
 It is recommended to use native tools (i.e. Windows programs on Windows), not Windows Subsystem for Linux (WSL) or a virtual machine.
 
-macOS is not officially supported quite yet. It is likely possible to build the firmware on macOS, and the emulator has limited support on Mac OS, requiring:
-
-- xquartz
-- libxinerama
-
-These can be obtained through [Homebrew](https://brew.sh/). Note that at this time, there is no sound on the macOS builds. When running on macOS, you will need to run the emulator through the xQuartz terminal instead. For running the formatter, cpp checker, docs generator, and more, you will need the following from Homebrew as well:
-
-- clang-format
-- cppcheck
-- wget
-- doxygen
-
 Espressif's installation guide notes limitations for the ESP-IDF's path:
 > The installation path of ESP-IDF and ESP-IDF Tools must not be longer than 90 characters.
 >
@@ -87,6 +75,21 @@ Note: Some installs of Python will have py.exe instead of python.exe - If this i
     git clone -b v5.1.1 --recurse-submodules https://github.com/espressif/esp-idf.git ~/esp/esp-idf
     ~/esp/esp-idf/install.sh
     ```
+
+## Configuring a MacOS Environment
+
+    > **Warning**
+    >
+    > This section is still under development, and as a result, may have unexpected errors in its process.
+
+1. Install [Homebrew](https://brew.sh/)
+2. Run the following command to install all necessary dependencies:
+    ```bash
+    brew install xquartz libxinerama clang-format cppcheck wget doxygen
+    ```
+
+
+Note that at this time, there is no sound on the macOS builds. When running on macOS, you will need to run the emulator through the xQuartz terminal instead. Building the firmware directly is also not supported fully yet at this time.
 
 ## Building and Flashing Firmware
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -11,7 +11,12 @@ macOS is not officially supported quite yet. It is likely possible to build the 
 - xquartz
 - libxinerama
 
-These can be obtained through [Homebrew](https://brew.sh/). Note that at this time, there is no sound on the macOS builds. When running on macOS, you will need to run the emulator through the xQuartz terminal instead.
+These can be obtained through [Homebrew](https://brew.sh/). Note that at this time, there is no sound on the macOS builds. When running on macOS, you will need to run the emulator through the xQuartz terminal instead. For running the formatter, cpp checker, docs generator, and more, you will need the following from Homebrew as well:
+
+- clang-format
+- cppcheck
+- wget
+- doxygen
 
 Espressif's installation guide notes limitations for the ESP-IDF's path:
 > The installation path of ESP-IDF and ESP-IDF Tools must not be longer than 90 characters.

--- a/emulator/src/components/hdw-esp-now/hdw-esp-now.c
+++ b/emulator/src/components/hdw-esp-now/hdw-esp-now.c
@@ -6,13 +6,15 @@
     #define USING_WINDOWS 1
 #elif defined(__linux__)
     #define USING_LINUX 1
+#elif __APPLE__
+    #define USING_MAC 1
 #else
     #error "OS Not Detected"
 #endif
 
 #if defined(USING_WINDOWS)
     #include <WinSock2.h>
-#elif defined(USING_LINUX)
+#elif defined(USING_LINUX) || defined(USING_MAC)
     #include <sys/socket.h> // for socket(), connect(), sendto(), and recvfrom()
     #include <arpa/inet.h>  // for sockaddr_in and inet_addr()
     #include <fcntl.h>

--- a/emulator/src/emu_main.c
+++ b/emulator/src/emu_main.c
@@ -109,7 +109,7 @@ void handleArgs(int argc, char** argv)
  */
 int main(int argc, char** argv)
 {
-#ifdef __linux__
+#ifdef __linux__ || __APPLE__
     init_crashSignals();
 #endif
 

--- a/emulator/src/emu_main.c
+++ b/emulator/src/emu_main.c
@@ -527,19 +527,19 @@ void signalHandler_crash(int signum, siginfo_t* si, void* vcontext)
         (void)result;
 
         memset(msg, 0, sizeof(msg));
-        #ifdef __linux__
-            for (int i = 0; i < __SI_PAD_SIZE; i++)
-        #else
-            // Seems to be hardcoded on MacOS
-            for (int i = 0; i < 7; i++)
-        #endif
+    #ifdef __linux__
+        for (int i = 0; i < __SI_PAD_SIZE; i++)
+    #else
+        // Seems to be hardcoded on MacOS
+        for (int i = 0; i < 7; i++)
+    #endif
         {
             char tmp[8];
-        #ifdef __linux__
+    #ifdef __linux__
             snprintf(tmp, sizeof(tmp), "%02X", si->_sifields._pad[i]);
-        #else
+    #else
             snprintf(tmp, sizeof(tmp), "%02X", (int)si->__pad[i]);
-        #endif
+    #endif
             tmp[sizeof(tmp) - 1] = '\0';
             strncat(msg, tmp, sizeof(msg) - strlen(msg) - 1);
         }

--- a/emulator/src/emu_main.c
+++ b/emulator/src/emu_main.c
@@ -3,7 +3,7 @@
 //==============================================================================
 
 #include <unistd.h>
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     #include <signal.h>
     #include <execinfo.h>
 #endif
@@ -63,7 +63,7 @@ static bool isRunning = true;
 // Function Prototypes
 //==============================================================================
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 void init_crashSignals(void);
 void signalHandler_crash(int signum, siginfo_t* si, void* vcontext);
 #endif
@@ -109,7 +109,7 @@ void handleArgs(int argc, char** argv)
  */
 int main(int argc, char** argv)
 {
-#ifdef __linux__ || __APPLE__
+#if defined(__linux__) || defined(__APPLE__)
     init_crashSignals();
 #endif
 
@@ -484,10 +484,10 @@ void HandleDestroy(void)
     WARN_UNIMPLEMENTED();
 }
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 
 /**
- * @brief Initialize a crash handler, only for Linux
+ * @brief Initialize a crash handler, only for Linux and MacOS
  */
 void init_crashSignals(void)
 {
@@ -503,7 +503,7 @@ void init_crashSignals(void)
 }
 
 /**
- * @brief Print a backtrace when a crash is caught, only for Linux
+ * @brief Print a backtrace when a crash is caught, only for Linux and MacOS
  *
  * @param signum
  * @param si
@@ -527,10 +527,19 @@ void signalHandler_crash(int signum, siginfo_t* si, void* vcontext)
         (void)result;
 
         memset(msg, 0, sizeof(msg));
-        for (int i = 0; i < __SI_PAD_SIZE; i++)
+        #ifdef __linux__
+            for (int i = 0; i < __SI_PAD_SIZE; i++)
+        #else
+            // Seems to be hardcoded on MacOS
+            for (int i = 0; i < 7; i++)
+        #endif
         {
             char tmp[8];
+        #ifdef __linux__
             snprintf(tmp, sizeof(tmp), "%02X", si->_sifields._pad[i]);
+        #else
+            snprintf(tmp, sizeof(tmp), "%02X", (int)si->__pad[i]);
+        #endif
             tmp[sizeof(tmp) - 1] = '\0';
             strncat(msg, tmp, sizeof(msg) - strlen(msg) - 1);
         }

--- a/emulator/src/rawdraw_sf.h
+++ b/emulator/src/rawdraw_sf.h
@@ -5329,7 +5329,9 @@ void AndroidSendToBack( int param )
 
 #include <stdio.h>
 #include <stdlib.h>
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 
 #ifdef HAS_XINERAMA
 	#include <X11/extensions/shape.h>

--- a/emulator/src/rawdraw_sf.h
+++ b/emulator/src/rawdraw_sf.h
@@ -565,7 +565,6 @@ static inline void DumpObjectClassProperties( jobject objToDump )
 
 
 #include <stdint.h>
-#include <malloc.h>
 
 typedef struct {
     uint32_t state[5];
@@ -3159,7 +3158,6 @@ void CNFGHandleInput()
 
 #include <windows.h>
 #include <stdlib.h>
-#include <malloc.h> //for alloca
 #include <ctype.h>
 
 HBITMAP CNFGlsBitmap;
@@ -5329,9 +5327,6 @@ void AndroidSendToBack( int param )
 
 #include <stdio.h>
 #include <stdlib.h>
-#ifndef __APPLE__
-#include <malloc.h>
-#endif
 
 #ifdef HAS_XINERAMA
 	#include <X11/extensions/shape.h>
@@ -6308,11 +6303,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 #ifdef _CNFG_FANCYFONT
 #include "TextTool/FontData.h"
-#endif
-
-//TODO: Refactor to remove malloc reliance.
-#ifndef __clang__
-#include <malloc.h>
 #endif
 
 int CNFGPenX, CNFGPenY;

--- a/emulator/src/sound/sound_pulse.c
+++ b/emulator/src/sound/sound_pulse.c
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 
     #include <pulse/simple.h>
     #include <pulse/pulseaudio.h>

--- a/main/modes/flight/flight.c
+++ b/main/modes/flight/flight.c
@@ -2661,7 +2661,8 @@ static void FlightNetworkFrameCall(flight_t* tflight, uint32_t now, modelRangePa
         bitct += WriteUEQ(&contents, 0);
         bitct += WriteUEQ(&contents, 1);
         bitct += WriteUEQ(&contents, NumActiveBoolets);
-        bitct += WriteUEQ(&contents, 0); // This is poisoned because of an oopsies with the Original Super 2024 Firmware. Do not use.
+        bitct += WriteUEQ(
+            &contents, 0); // This is poisoned because of an oopsies with the Original Super 2024 Firmware. Do not use.
         bitct += WriteUEQ(&contents, 0); // The number of chars to display (first char is color)
         FinalizeUEQ(&contents, bitct);
         *((uint32_t*)pp) = contents;
@@ -2733,7 +2734,8 @@ static void FlightfnEspNowRecvCb(const esp_now_recv_info_t* esp_now_info, const 
     int i;
     flight_t* flt = flight;
 
-    if (!flt) return;
+    if (!flt)
+        return;
 
     if (flt->nNetworkMode == 0)
         return;
@@ -2826,7 +2828,7 @@ static void FlightfnEspNowRecvCb(const esp_now_recv_info_t* esp_now_info, const 
     int shipCount   = ReadUEQ(&assetCounts);
     int booletCount = ReadUEQ(&assetCounts);
     ReadUEQ(&assetCounts); // DO NOT USE, poisoned from 2024 Firmware
-    int textLength  = ReadUEQ(&assetCounts);
+    int textLength = ReadUEQ(&assetCounts);
     // If we get a server packet, switch to server mode for a while.
     if (!isPeer)
     {

--- a/main/modes/mfpaint/paint_nvs.h
+++ b/main/modes/mfpaint/paint_nvs.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #ifndef __APPLE__
-#include <malloc.h>
+    #include <malloc.h>
 #endif
 
 #include "settingsManager.h"

--- a/main/modes/mfpaint/paint_nvs.h
+++ b/main/modes/mfpaint/paint_nvs.h
@@ -3,7 +3,9 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 
 #include "settingsManager.h"
 #include "hdw-nvs.h"

--- a/main/modes/mfpaint/paint_nvs.h
+++ b/main/modes/mfpaint/paint_nvs.h
@@ -3,9 +3,6 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#ifndef __APPLE__
-    #include <malloc.h>
-#endif
 
 #include "settingsManager.h"
 #include "hdw-nvs.h"

--- a/main/modes/mfpaint/paint_ui.c
+++ b/main/modes/mfpaint/paint_ui.c
@@ -1,6 +1,8 @@
 #include "paint_ui.h"
 
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 #include <string.h>
 
 #include "shapes.h"

--- a/main/modes/mfpaint/paint_ui.c
+++ b/main/modes/mfpaint/paint_ui.c
@@ -1,7 +1,7 @@
 #include "paint_ui.h"
 
 #ifndef __APPLE__
-#include <malloc.h>
+    #include <malloc.h>
 #endif
 #include <string.h>
 

--- a/main/modes/mfpaint/paint_ui.c
+++ b/main/modes/mfpaint/paint_ui.c
@@ -1,8 +1,5 @@
 #include "paint_ui.h"
 
-#ifndef __APPLE__
-    #include <malloc.h>
-#endif
 #include <string.h>
 
 #include "shapes.h"

--- a/main/modes/mfpaint/px_stack.c
+++ b/main/modes/mfpaint/px_stack.c
@@ -1,6 +1,8 @@
 #include "px_stack.h"
 
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>

--- a/main/modes/mfpaint/px_stack.c
+++ b/main/modes/mfpaint/px_stack.c
@@ -1,7 +1,7 @@
 #include "px_stack.h"
 
 #ifndef __APPLE__
-#include <malloc.h>
+    #include <malloc.h>
 #endif
 #include <stddef.h>
 #include <stdint.h>

--- a/main/modes/mfpaint/px_stack.c
+++ b/main/modes/mfpaint/px_stack.c
@@ -1,8 +1,5 @@
 #include "px_stack.h"
 
-#ifndef __APPLE__
-    #include <malloc.h>
-#endif
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>

--- a/main/modes/quickSettings/menuQuickSettingsRenderer.c
+++ b/main/modes/quickSettings/menuQuickSettingsRenderer.c
@@ -11,9 +11,6 @@
 #include "palette.h"
 #include "esp_log.h"
 
-#ifndef __APPLE__
-    #include <malloc.h>
-#endif
 #include <stdint.h>
 #include <inttypes.h>
 

--- a/main/modes/quickSettings/menuQuickSettingsRenderer.c
+++ b/main/modes/quickSettings/menuQuickSettingsRenderer.c
@@ -11,7 +11,9 @@
 #include "palette.h"
 #include "esp_log.h"
 
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 #include <stdint.h>
 #include <inttypes.h>
 

--- a/main/modes/quickSettings/menuQuickSettingsRenderer.c
+++ b/main/modes/quickSettings/menuQuickSettingsRenderer.c
@@ -12,7 +12,7 @@
 #include "esp_log.h"
 
 #ifndef __APPLE__
-#include <malloc.h>
+    #include <malloc.h>
 #endif
 #include <stdint.h>
 #include <inttypes.h>

--- a/main/utils/dialogBox.c
+++ b/main/utils/dialogBox.c
@@ -9,7 +9,9 @@
 #include "palette.h"
 #include "fill.h"
 
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 #include <stdint.h>
 
 //==============================================================================

--- a/main/utils/dialogBox.c
+++ b/main/utils/dialogBox.c
@@ -9,9 +9,6 @@
 #include "palette.h"
 #include "fill.h"
 
-#ifndef __APPLE__
-    #include <malloc.h>
-#endif
 #include <stdint.h>
 
 //==============================================================================

--- a/main/utils/dialogBox.c
+++ b/main/utils/dialogBox.c
@@ -10,7 +10,7 @@
 #include "fill.h"
 
 #ifndef __APPLE__
-#include <malloc.h>
+    #include <malloc.h>
 #endif
 #include <stdint.h>
 

--- a/main/utils/macros.h
+++ b/main/utils/macros.h
@@ -37,11 +37,6 @@
  */
 #define ABS(a) (((a) < (0)) ? -(a) : (a))
 
-/// Helper macro to determine the number of elements in an array. Should not be used directly
-#define IS_ARRAY(arr) ((void*)&(arr) == &(arr)[0])
-
-/// Helper macro to determine the number of elements in an array. Should not be used directly
-#define STATIC_EXP(e) (0 * sizeof(struct { int ARRAY_SIZE_FAILED : (2 * (e)-1); }))
 
 /**
  * @brief Return the number of elements in a fixed length array. This does not work for pointers.
@@ -51,7 +46,26 @@
  * @param arr An array to find the number of elements in
  * @return The the number of elements in an array (not the byte size!)
  */
+#ifdef __APPLE__
+/* Force a compilation error if condition is true, but also produce a
+   result (of value 0 and type size_t), so the expression can be used
+   e.g. in a structure initializer (or where-ever else comma expressions
+   aren't permitted). */
+#define BUILD_BUG_ON_ZERO(e) (sizeof(struct { int:-!!(e); }))
+
+/// Helper macro to determine the number of elements in an array. Should not be used directly
+#define __must_be_array(a) BUILD_BUG_ON_ZERO(__builtin_types_compatible_p(typeof(a), typeof(&(a)[0])))
+
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]) + __must_be_array(arr))
+#else
+/// Helper macro to determine the number of elements in an array. Should not be used directly
+#define IS_ARRAY(arr) ((void*)&(arr) == &(arr)[0])
+
+/// Helper macro to determine the number of elements in an array. Should not be used directly
+#define STATIC_EXP(e) (0 * sizeof(struct { int ARRAY_SIZE_FAILED : (2 * (e)-1); }))
+
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]) + STATIC_EXP(IS_ARRAY(arr)))
+#endif
 
 /**
  * @brief Returns (a + b) % d, but with negative values converted to equivalent positive values.

--- a/main/utils/macros.h
+++ b/main/utils/macros.h
@@ -37,7 +37,6 @@
  */
 #define ABS(a) (((a) < (0)) ? -(a) : (a))
 
-
 /**
  * @brief Return the number of elements in a fixed length array. This does not work for pointers.
  *
@@ -47,24 +46,24 @@
  * @return The the number of elements in an array (not the byte size!)
  */
 #ifdef __APPLE__
-/* Force a compilation error if condition is true, but also produce a
-   result (of value 0 and type size_t), so the expression can be used
-   e.g. in a structure initializer (or where-ever else comma expressions
-   aren't permitted). */
-#define BUILD_BUG_ON_ZERO(e) (sizeof(struct { int:-!!(e); }))
+    /* Force a compilation error if condition is true, but also produce a
+       result (of value 0 and type size_t), so the expression can be used
+       e.g. in a structure initializer (or where-ever else comma expressions
+       aren't permitted). */
+    #define BUILD_BUG_ON_ZERO(e) (sizeof(struct { int : -!!(e); }))
 
-/// Helper macro to determine the number of elements in an array. Should not be used directly
-#define __must_be_array(a) BUILD_BUG_ON_ZERO(__builtin_types_compatible_p(typeof(a), typeof(&(a)[0])))
+    /// Helper macro to determine the number of elements in an array. Should not be used directly
+    #define __must_be_array(a) BUILD_BUG_ON_ZERO(__builtin_types_compatible_p(typeof(a), typeof(&(a)[0])))
 
-#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]) + __must_be_array(arr))
+    #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]) + __must_be_array(arr))
 #else
-/// Helper macro to determine the number of elements in an array. Should not be used directly
-#define IS_ARRAY(arr) ((void*)&(arr) == &(arr)[0])
+    /// Helper macro to determine the number of elements in an array. Should not be used directly
+    #define IS_ARRAY(arr) ((void*)&(arr) == &(arr)[0])
 
-/// Helper macro to determine the number of elements in an array. Should not be used directly
-#define STATIC_EXP(e) (0 * sizeof(struct { int ARRAY_SIZE_FAILED : (2 * (e)-1); }))
+    /// Helper macro to determine the number of elements in an array. Should not be used directly
+    #define STATIC_EXP(e) (0 * sizeof(struct { int ARRAY_SIZE_FAILED : (2 * (e)-1); }))
 
-#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]) + STATIC_EXP(IS_ARRAY(arr)))
+    #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]) + STATIC_EXP(IS_ARRAY(arr)))
 #endif
 
 /**

--- a/main/utils/touchTextEntry.c
+++ b/main/utils/touchTextEntry.c
@@ -6,7 +6,7 @@
 
 #include <string.h>
 #ifndef __APPLE__
-#include <malloc.h>
+    #include <malloc.h>
 #endif
 
 #include "font.h"

--- a/main/utils/touchTextEntry.c
+++ b/main/utils/touchTextEntry.c
@@ -5,9 +5,6 @@
 #include "touchTextEntry.h"
 
 #include <string.h>
-#ifndef __APPLE__
-    #include <malloc.h>
-#endif
 
 #include "font.h"
 #include "hdw-btn.h"

--- a/main/utils/touchTextEntry.c
+++ b/main/utils/touchTextEntry.c
@@ -5,7 +5,9 @@
 #include "touchTextEntry.h"
 
 #include <string.h>
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 
 #include "font.h"
 #include "hdw-btn.h"

--- a/main/utils/wheel_menu.c
+++ b/main/utils/wheel_menu.c
@@ -14,7 +14,7 @@
 
 #include <inttypes.h>
 #ifndef __APPLE__
-#include <malloc.h>
+    #include <malloc.h>
 #endif
 #include <string.h>
 

--- a/main/utils/wheel_menu.c
+++ b/main/utils/wheel_menu.c
@@ -13,9 +13,6 @@
 #include "esp_log.h"
 
 #include <inttypes.h>
-#ifndef __APPLE__
-    #include <malloc.h>
-#endif
 #include <string.h>
 
 //==============================================================================

--- a/main/utils/wheel_menu.c
+++ b/main/utils/wheel_menu.c
@@ -13,7 +13,9 @@
 #include "esp_log.h"
 
 #include <inttypes.h>
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 #include <string.h>
 
 //==============================================================================

--- a/makefile
+++ b/makefile
@@ -92,7 +92,8 @@ CFLAGS += \
 else
 # Required for OpenGL and some other libraries
 CFLAGS += \
-	-I/opt/X11/include
+	-I/opt/X11/include \
+	-I/opt/homebrew/include
 endif
 
 ifeq ($(HOST_OS),Linux)
@@ -219,9 +220,8 @@ endif
 ifeq ($(HOST_OS),Linux)
     LIBS = m X11 asound pulse rt GL GLX pthread Xext Xinerama
 endif
-# Todo: Figure out an alternative to asound on MacOS
 ifeq ($(HOST_OS),Darwin)
-    LIBS = m X11 GL pthread Xext Xinerama
+    LIBS = m X11 GL pulse pthread Xext Xinerama
 endif
 
 # These are directories to look for library files in
@@ -229,7 +229,7 @@ LIB_DIRS =
 
 # On MacOS we need to ensure that X11 is added for OpenGL and some others
 ifeq ($(HOST_OS),Darwin)
-    LIB_DIRS = /opt/X11/lib
+    LIB_DIRS = /opt/X11/lib /opt/homebrew/lib
 endif
 
 # This combines the flags for the linker to find and use libraries

--- a/tools/font_maker/makefile
+++ b/tools/font_maker/makefile
@@ -109,7 +109,6 @@ LIB_DIRS =
 
 # This combines the flags for the linker to find and use libraries
 LIBRARY_FLAGS = $(patsubst %, -L%, $(LIB_DIRS)) $(patsubst %, -l%, $(LIBS)) \
-	-static-libgcc \
 	-static-libstdc++ \
 	-ggdb
 

--- a/tools/spiffs_file_preprocessor/makefile
+++ b/tools/spiffs_file_preprocessor/makefile
@@ -120,7 +120,6 @@ LIB_DIRS =
 
 # This combines the flags for the linker to find and use libraries
 LIBRARY_FLAGS = $(patsubst %, -L%, $(LIB_DIRS)) $(patsubst %, -l%, $(LIBS)) \
-	-static-libgcc \
 	-static-libstdc++ \
 	-ggdb
 

--- a/tools/spiffs_file_preprocessor/src/heatshrink_util.c
+++ b/tools/spiffs_file_preprocessor/src/heatshrink_util.c
@@ -127,6 +127,9 @@ void writeHeatshrinkFile(uint8_t* input, uint32_t len, const char* outFilePath)
 
     /* Write a compressed file */
     shrunkFile = fopen(outFilePath, "wb");
+    if (shrunkFile == NULL) {
+        perror("Error occurred while writing file.\n");
+    }
     /* First four bytes are decompresed size */
     putc(HI_BYTE(HI_WORD(len)), shrunkFile);
     putc(LO_BYTE(HI_WORD(len)), shrunkFile);

--- a/tools/spiffs_file_preprocessor/src/spiffs_file_preprocessor.c
+++ b/tools/spiffs_file_preprocessor/src/spiffs_file_preprocessor.c
@@ -157,7 +157,7 @@ int main(int argc, char** argv)
     {
 #if defined(_WIN32)
         mkdir(outDirName);
-#elif defined(__linux__) || defined(__CYGWIN__) || defined(__APPLE_)
+#elif defined(__linux__) || defined(__CYGWIN__) || defined(__APPLE__)
         mkdir(outDirName, 0777);
 #endif
     }

--- a/tools/spiffs_file_preprocessor/src/spiffs_file_preprocessor.c
+++ b/tools/spiffs_file_preprocessor/src/spiffs_file_preprocessor.c
@@ -157,7 +157,7 @@ int main(int argc, char** argv)
     {
 #if defined(_WIN32)
         mkdir(outDirName);
-#elif defined(__linux__) || defined(__CYGWIN__)
+#elif defined(__linux__) || defined(__CYGWIN__) || defined(__APPLE_)
         mkdir(outDirName, 0777);
 #endif
     }


### PR DESCRIPTION
### Description

[Problem]
Attempting to build on a MacOS device currently fails due to a variety of issues. This includes:

- Referencing "malloc.h"
- Missing checks for Apple compiler flags
- Incompatible compiler and linker flags for MacOS' clang gcc version
- The ARRAY_SIZE macro not being compatible with the MacOS' clang gcc version
- Incompatible sound library (asound)

[Solution]
This change fixes the above issues and updates the documentation for how to use on MacOS. Sound currently is a work in progress as a new sound library is searched for to use.

### Test Instructions

Built and confirmed that the simulator runs in XQuartz now, ensuring that a few different games are up and running.

### Ticket Links

### Readiness Checklist
- [X] I have run `make format` to format the changes
- [X] I have compiled the firmware and the changes have no warnings
- [X] I have compiled the emulator and the changes have no warnings
- [X] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [X] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [X] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
