### PR TITLE
Typo

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -85,15 +85,20 @@ Note: Some installs of Python will have py.exe instead of python.exe - If this i
 1. Install [Homebrew](https://brew.sh/)
 2. Run the following command to install all necessary dependencies:
     ```bash
-    brew install xquartz libxinerama pulseaudio clang-format cppcheck wget doxygen
+    brew install xquartz libxinerama pulseaudio clang-format cppcheck wget doxygen cmake
     ```
-3. Before running the simulator on your machine, you need to start pulseaudio like so:
+3. Clone the ESP-IDF v5.1.1 and install the tools. Note that it will clone into `~/esp/esp-idf`.
+    ```bash
+    git clone -b v5.1.1 --recurse-submodules https://github.com/espressif/esp-idf.git ~/esp/esp-idf
+    ~/esp/esp-idf/install.sh
+    ```
+4. Before running the simulator on your machine, you need to start pulseaudio like so:
     ```bash
     brew services start pulseaudio
     ```
-    You can stop it by running `brew services start pulseaudio` when you are done.
-
-When running on macOS, you will need to run the emulator through the xQuartz terminal instead. Building the firmware directly is also not supported fully yet at this time.
+    You can stop it by running `brew services stop pulseaudio` when you are done.
+    
+When running on MacOS, you will need to run the emulator and all build tasks through the xQuartz terminal instead of zsh.
 
 ## Building and Flashing Firmware
 
@@ -113,6 +118,7 @@ When running on macOS, you will need to run the emulator through the xQuartz ter
     ```powershell
     idf.py -p COM8 -b 2000000 build flash
     ```
+      - For Linux and MacOS, use /dev/tty\[devicename] and /dev/cu.\[devicename]
 4. Automatic Flashing
     1. Once the Swadge is plugged in and powered on, run this single command which will build the firmware, reboot the Swadge into bootloader mode, flash the firmware, reboot the Swadge again, and open up a serial terminal for debug output.
     ```bash


### PR DESCRIPTION
### Description

Adding some details to the MacOS getting started section:
- Added 'cmake' to install list
- Added esp-idf download and install instructions from the linux section
- Changed `brew services **start** pulseaudio` to `brew services **stop** pulseaudio`
- Updated language indicating MacOS isn't capable of building the firmware
- Updated the COM step with a note about /dev/tty.* for linux and /dev/cu.* for MacOS.

### Test Instructions

- Fresh install of MacOS (All brew packages removed)
- Followed new guidelines 
- Able to build and flash Swadge

### Ticket Links

https://github.com/AEFeinstein/Super-2024-Swadge-FW/issues/204

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
