### PR TITLE
Use more environment variables for OS detection

### DIFF
--- a/emulator/src/components/hdw-esp-now/hdw-esp-now.c
+++ b/emulator/src/components/hdw-esp-now/hdw-esp-now.c
@@ -2,10 +2,14 @@
 // Includes
 //==============================================================================
 
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64) || defined(__MINGW32__) \
-    || defined(__CYGWIN__)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__) || defined(_MSC_VER)
     #define USING_WINDOWS 1
-#elif defined(__linux__)
+#elif defined(__linux) || defined(__linux__) || defined(linux) || defined(__LINUX__)
     #define USING_LINUX 1
 #elif __APPLE__
     #define USING_MAC 1

--- a/emulator/src/components/hdw-esp-now/hdw-esp-now.c
+++ b/emulator/src/components/hdw-esp-now/hdw-esp-now.c
@@ -2,6 +2,7 @@
 // Includes
 //==============================================================================
 
+// clang-format off
 #if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
                      || defined(WIN32)       || defined(WIN64) \
                      || defined(_WIN32)      || defined(_WIN64) \
@@ -16,6 +17,7 @@
 #else
     #error "OS Not Detected"
 #endif
+// clang-format on
 
 #if defined(USING_WINDOWS)
     #include <WinSock2.h>

--- a/emulator/src/components/hdw-nvs/cJSON.h
+++ b/emulator/src/components/hdw-nvs/cJSON.h
@@ -28,6 +28,7 @@ extern "C"
 {
 #endif
 
+// clang-format off
 #if !defined(__WINDOWS__) && (defined(WINDOWS) || defined(_WINDOWS) \
                            || defined(WIN32)       || defined(WIN64) \
                            || defined(_WIN32)      || defined(_WIN64) \
@@ -36,6 +37,7 @@ extern "C"
                            || defined(__TOS_WIN__) || defined(_MSC_VER))
 #define __WINDOWS__
 #endif
+// clang-format on
 
 #ifdef __WINDOWS__
 

--- a/emulator/src/components/hdw-nvs/cJSON.h
+++ b/emulator/src/components/hdw-nvs/cJSON.h
@@ -28,7 +28,12 @@ extern "C"
 {
 #endif
 
-#if !defined(__WINDOWS__) && (defined(WIN32) || defined(WIN64) || defined(_MSC_VER) || defined(_WIN32))
+#if !defined(__WINDOWS__) && (defined(WINDOWS) || defined(_WINDOWS) \
+                           || defined(WIN32)       || defined(WIN64) \
+                           || defined(_WIN32)      || defined(_WIN64) \
+                           || defined(__WIN32__)   || defined(__CYGWIN__) \
+                           || defined(__MINGW32__) || defined(__MINGW64__) \
+                           || defined(__TOS_WIN__) || defined(_MSC_VER))
 #define __WINDOWS__
 #endif
 

--- a/emulator/src/emu_main.c
+++ b/emulator/src/emu_main.c
@@ -41,6 +41,7 @@
 #include "hdw-esp-now.h"
 #include "mainMenu.h"
 
+// clang-format off
 // Necessary for CNFA
 #if !defined(WINDOWS) && ( defined(__WINDOWS__) || defined(_WINDOWS) \
                         || defined(WIN32)       || defined(WIN64) \
@@ -50,6 +51,7 @@
                         || defined(__TOS_WIN__) || defined(_MSC_VER))
     #define WINDOWS
 #endif
+// clang-format on
 
 // Make it so we don't need to include any other C files in our build.
 #define CNFG_IMPLEMENTATION
@@ -171,8 +173,8 @@ int main(int argc, char** argv)
         calculatePaneMinimums(paneMins);
         int32_t sidePanesW      = paneMins[PANE_LEFT].min + paneMins[PANE_RIGHT].min;
         int32_t topBottomPanesH = paneMins[PANE_TOP].min + paneMins[PANE_BOTTOM].min;
-        int32_t winW            = (TFT_WIDTH)*2 + sidePanesW;
-        int32_t winH            = (TFT_HEIGHT)*2 + topBottomPanesH;
+        int32_t winW            = (TFT_WIDTH) * 2 + sidePanesW;
+        int32_t winH            = (TFT_HEIGHT) * 2 + topBottomPanesH;
 
         if (emulatorArgs.headless)
         {
@@ -580,6 +582,7 @@ int HandleDestroy()
 
     if (soundDriver)
     {
+        // clang-format off
 #if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
                      || defined(WIN32)       || defined(WIN64) \
                      || defined(_WIN32)      || defined(_WIN64) \
@@ -590,6 +593,7 @@ int HandleDestroy()
 #else
         CNFAClose(soundDriver); // when calling this on Windows, it halts
 #endif
+        // clang-format on
         soundDriver = NULL;
     }
 

--- a/emulator/src/emu_main.c
+++ b/emulator/src/emu_main.c
@@ -3,7 +3,7 @@
 //==============================================================================
 
 #include <unistd.h>
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux) || defined(__linux__) || defined(linux) || defined(__LINUX__) || defined(__APPLE__)
     #include <signal.h>
     #include <execinfo.h>
 #endif
@@ -42,8 +42,12 @@
 #include "mainMenu.h"
 
 // Necessary for CNFA
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64) || defined(__MINGW32__) \
-    || defined(__CYGWIN__)
+#if !defined(WINDOWS) && ( defined(__WINDOWS__) || defined(_WINDOWS) \
+                        || defined(WIN32)       || defined(WIN64) \
+                        || defined(_WIN32)      || defined(_WIN64) \
+                        || defined(__WIN32__)   || defined(__CYGWIN__) \
+                        || defined(__MINGW32__) || defined(__MINGW64__) \
+                        || defined(__TOS_WIN__) || defined(_MSC_VER))
     #define WINDOWS
 #endif
 
@@ -53,7 +57,7 @@
 #include "CNFG.h"
 
 #define CNFA_IMPLEMENTATION
-#ifdef __linux__
+#if defined(__linux) || defined(__linux__) || defined(linux) || defined(__LINUX__)
     #define PULSEAUDIO
 #endif
 #include "CNFA.h"
@@ -85,7 +89,7 @@ static struct CNFADriver* soundDriver = NULL;
 // Function Prototypes
 //==============================================================================
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux) || defined(__linux__) || defined(linux) || defined(__LINUX__) || defined(__APPLE__)
 void init_crashSignals(void);
 void signalHandler_crash(int signum, siginfo_t* si, void* vcontext);
 #endif
@@ -131,7 +135,7 @@ void handleArgs(int argc, char** argv)
  */
 int main(int argc, char** argv)
 {
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux) || defined(__linux__) || defined(linux) || defined(__LINUX__) || defined(__APPLE__)
     init_crashSignals();
 #endif
 
@@ -576,7 +580,12 @@ int HandleDestroy()
 
     if (soundDriver)
     {
-#if defined(_WIN32) || defined(__CYGWIN__)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__) || defined(_MSC_VER)
         CNFAClose(NULL);
 #else
         CNFAClose(soundDriver); // when calling this on Windows, it halts
@@ -611,7 +620,7 @@ static void EmuSoundCb(struct CNFADriver* sd, short* out, short* in, int framesp
 #endif
 }
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux) || defined(__linux__) || defined(linux) || defined(__LINUX__) || defined(__APPLE__)
 
 /**
  * @brief Initialize a crash handler, only for Linux and MacOS
@@ -654,7 +663,7 @@ void signalHandler_crash(int signum, siginfo_t* si, void* vcontext)
         (void)result;
 
         memset(msg, 0, sizeof(msg));
-    #ifdef __linux__
+    #if defined(__linux) || defined(__linux__) || defined(linux) || defined(__LINUX__)
         for (int i = 0; i < __SI_PAD_SIZE; i++)
     #else
         // Seems to be hardcoded on MacOS
@@ -662,7 +671,7 @@ void signalHandler_crash(int signum, siginfo_t* si, void* vcontext)
     #endif
         {
             char tmp[8];
-    #ifdef __linux__
+    #if defined(__linux) || defined(__linux__) || defined(linux) || defined(__LINUX__)
             snprintf(tmp, sizeof(tmp), "%02X", si->_sifields._pad[i]);
     #else
             snprintf(tmp, sizeof(tmp), "%02X", (int)si->__pad[i]);

--- a/tools/hidapi.c
+++ b/tools/hidapi.c
@@ -1,4 +1,9 @@
-#ifdef _WIN32
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__) || defined(_MSC_VER)
 
 /*******************************************************
  HIDAPI - Multi-Platform library for
@@ -42,7 +47,7 @@
 typedef LONG NTSTATUS;
 #endif
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__) || defined(__MINGW64__)
 #include <ntdef.h>
 #include <winbase.h>
 #endif
@@ -58,8 +63,12 @@ typedef LONG NTSTATUS;
 
 /*#define HIDAPI_USE_DDK*/
 
-#if defined(WINDOWS) || defined(WIN32)  || defined(WIN64) \
-                     || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__) || defined(_MSC_VER)
 #ifndef strdup
 #define strdup _strdup
 #endif
@@ -2153,7 +2162,7 @@ int main(void)
 #endif
 
 
-#elif defined(__linux__)
+#elif defined(__linux) || defined(__linux__) || defined(linux) || defined(__LINUX__)
 
 /*******************************************************
  HIDAPI - Multi-Platform library for
@@ -3002,13 +3011,13 @@ HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
 
 /* GNU / LibUSB */
 #include <libusb.h>
-#ifndef __ANDROID__
+#if !(defined(__ANDROID__) || defined(__android__) || defined(ANDROID))
 #include <iconv.h>
 #endif
 
 #include "hidapi.h"
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__) || defined(__android__) || defined(ANDROID)
 
 /* Barrier implementation because Android/Bionic don't have pthread_barrier.
    This implementation came from Brent Priddy and was posted on
@@ -3347,7 +3356,7 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 	int len;
 	wchar_t *str = NULL;
 
-#ifndef __ANDROID__ /* we don't use iconv on Android */
+#if !(defined(__ANDROID__) || defined(__android__) || defined(ANDROID)) /* we don't use iconv on Android */
 	wchar_t wbuf[256];
 	/* iconv variables */
 	iconv_t ic;
@@ -3377,7 +3386,7 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 	if (len < 0)
 		return NULL;
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__) || defined(__android__) || defined(ANDROID)
 
 	/* Bionic does not have iconv support nor wcsdup() function, so it
 	   has to be done manually.  The following code will only work for

--- a/tools/spiffs_file_preprocessor/src-lib/cJSON.h
+++ b/tools/spiffs_file_preprocessor/src-lib/cJSON.h
@@ -28,7 +28,12 @@ extern "C"
 {
 #endif
 
-#if !defined(__WINDOWS__) && (defined(WIN32) || defined(WIN64) || defined(_MSC_VER) || defined(_WIN32))
+#if !defined(__WINDOWS__) && (defined(WINDOWS) || defined(_WINDOWS) \
+                           || defined(WIN32)       || defined(WIN64) \
+                           || defined(_WIN32)      || defined(_WIN64) \
+                           || defined(__WIN32__)   || defined(__CYGWIN__) \
+                           || defined(__MINGW32__) || defined(__MINGW64__) \
+                           || defined(__TOS_WIN__) || defined(_MSC_VER))
 #define __WINDOWS__
 #endif
 

--- a/tools/spiffs_file_preprocessor/src/spiffs_file_preprocessor.c
+++ b/tools/spiffs_file_preprocessor/src/spiffs_file_preprocessor.c
@@ -155,9 +155,13 @@ int main(int argc, char** argv)
     struct stat st = {0};
     if (stat(outDirName, &st) == -1)
     {
-#if defined(_WIN32)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__TOS_WIN__) \
+                     || defined(_MSC_VER)
         mkdir(outDirName);
-#elif defined(__linux__) || defined(__CYGWIN__) || defined(__APPLE__)
+#elif defined(__linux) || defined(__linux__) || defined(linux) || defined(__LINUX__) || defined(__CYGWIN__) || defined(__APPLE__)
         mkdir(outDirName, 0777);
 #endif
     }


### PR DESCRIPTION
### Description

I've replaced a ton of preprocessor OS detections in rawdraw, cnfa, and the swadge repo. However, I didn't replace all of them, especially where it looked like the author was intentionally not using all possible environment variable names (that they knew of) to detect a certain OS.

This fixes an issue where `make usbflash` fails to work on Windows with the current toolchain.

Respective PRs for the submodules can be found here for [rawdraw](https://github.com/cntools/rawdraw/pull/106) and [cnfa](https://github.com/cntools/cnfa/pull/23).

### Test Instructions
As a warning, I've only tested this in a Windows Cygwin environment, so other environments and OSes still need to be tested.

### Readiness Checklist

`make format` failed with the following error:
```Error reading /cygdrive/d/Bryce/Documents/MAGFest/Swadge-2024/Swadge-IDF-5.0/.clang-format: Invalid argument
YAML:14:3: error: unexpected scalar
  Kind: Always
  ^
```

As for compile warnings, too many have slipped past into this repo for me to be able to easily check for new ones. I can check by hand, if required.

- [ ] ~~I have run `make format` to format the changes~~
- [ ] ~~I have compiled the firmware and the changes have no warnings~~
- [ ] ~~I have compiled the emulator and the changes have no warnings~~
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
