### PR TITLE
Fix drawWsgSimpleScaled() misbehaving on negative Y assets. Fixes #228

### DIFF
--- a/main/display/wsg.c
+++ b/main/display/wsg.c
@@ -370,6 +370,7 @@ void drawWsgSimpleScaled(const wsg_t* wsg, int16_t xOff, int16_t yOff, int16_t x
         // Entire "pixel" is off-screen
         if (y1 <= 0)
         {
+            linein += wWidth;
             continue;
         }
 


### PR DESCRIPTION
### Description

This fixes the issue with  `drawWsgSimpleScaled()` described in #228. When the Y-offset is negative, the drawing of the line is skipped but the pointer to the WSG data isn't advanced, so instead the image is drawn at Y=0, and however many lines should have been skipped drawing at the beginning are skipped at the end instead.

### Test Instructions

Test by drawing some scaled WSGs with a negative Y offset and making sure they're drawn correctly.

### Ticket Links

Closes #228 

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
