### PR TITLE
Re-style quick settings to match mania menu

### DIFF
--- a/main/modes/system/quickSettings/menuQuickSettingsRenderer.c
+++ b/main/modes/system/quickSettings/menuQuickSettingsRenderer.c
@@ -28,13 +28,13 @@
 
 #define TEXT_MARGIN 10
 
-#define PANEL_BG_COLOR            c200
-#define PANEL_BORDER_COLOR        c532
-#define PANEL_ICON_BG_COLOR_SEL   c411
-#define PANEL_ICON_BG_COLOR_UNSEL c311
-#define PANEL_ICON_BG_COLOR_OFF   c222
-#define PANEL_BOX_COLOR_SEL       c532
-#define PANEL_BOX_COLOR_UNSEL     c200
+#define PANEL_BG_COLOR            c115
+#define PANEL_BORDER_COLOR        c000
+#define PANEL_ICON_BG_COLOR_SEL   c243
+#define PANEL_ICON_BG_COLOR_UNSEL c114
+#define PANEL_ICON_BG_COLOR_OFF   c444
+#define PANEL_BOX_COLOR_SEL       c555
+#define PANEL_BOX_COLOR_UNSEL     c531
 #define PANEL_TEXT_COLOR          c542
 
 #define ICON_W      16


### PR DESCRIPTION
### Description

Update the colors of the quick settings menu to better match the mania menu renderer.

### Test Instructions

:eye: :eye:
![screenshot-1719872556505](https://github.com/AEFeinstein/Super-2024-Swadge-FW/assets/666431/3d4ff4fc-f132-43e7-88aa-f72f3366d373)
![screenshot-1719872573871](https://github.com/AEFeinstein/Super-2024-Swadge-FW/assets/666431/4c89615b-589b-4434-90ce-418655cf1795)
![screenshot-1719872581572](https://github.com/AEFeinstein/Super-2024-Swadge-FW/assets/666431/9e107d88-cb4e-4902-9e1b-a8217e79af83)
![screenshot-1719872586539](https://github.com/AEFeinstein/Super-2024-Swadge-FW/assets/666431/6883299d-d174-4c3a-aa1b-423dac67f732)
![screenshot-1719872589804](https://github.com/AEFeinstein/Super-2024-Swadge-FW/assets/666431/9574e1db-8ae7-48eb-b4b3-96acc7e06485)


### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
