### PR TITLE
More keyboard funcs

### DIFF
--- a/main/modes/test/keebTest/keebTest.c
+++ b/main/modes/test/keebTest/keebTest.c
@@ -238,14 +238,17 @@ static void keebMainLoop(int64_t elapsedUs)
             drawMenuMania(kbTest->menu, kbTest->renderer, elapsedUs);
             break;
         case TYPING:
-            drawIncidentalBG();
+            bool drawlines = true;
             while (checkButtonQueueWrapper(&evt))
             {
                 if (!textEntryInput(evt.down, evt.button))
                 {
                     kbTest->currState = DISPLAYING;
+                    drawlines         = false;
                 }
             }
+            if (drawlines)
+                drawIncidentalBG();
             textEntryDraw(elapsedUs);
             if (kbTest->count)
             {

--- a/main/modes/test/keebTest/keebTest.c
+++ b/main/modes/test/keebTest/keebTest.c
@@ -2,7 +2,7 @@
  * @file keebTest.c
  * @author Jeremy Stintzcum (jeremy.stintzcum@gmail.com)
  * @brief A mode designed to test keyboard variations in rapid succession
- * @version 1.0
+ * @version 1.1
  * @date 2024-07-06
  *
  * @copyright Copyright (c) 2024

--- a/main/modes/test/keebTest/keebTest.c
+++ b/main/modes/test/keebTest/keebTest.c
@@ -100,6 +100,7 @@ static const char teMenuEnter[]        = "Enter Style";
 static const char teMenuCaps[]         = "Caps Style";
 static const char teMenuMulti[]        = "Multiline";
 static const char teMenuCount[]        = "Char Count";
+static const char teMenuPrompt[]       = "Sample Prompt";
 static const char teMenuReset[]        = "Reset String";
 static const char teMenuResetHard[]    = "Reset TextEntry";
 
@@ -191,6 +192,7 @@ static void keebEnterMode(void)
     addSingleItemToMenu(kbTest->menu, teMenuCaps);
     addSingleItemToMenu(kbTest->menu, teMenuMulti);
     addSingleItemToMenu(kbTest->menu, teMenuCount);
+    addSingleItemToMenu(kbTest->menu, teMenuPrompt);
     addSingleItemToMenu(kbTest->menu, teMenuReset);
     addSingleItemToMenu(kbTest->menu, teMenuResetHard);
 
@@ -228,6 +230,7 @@ static void keebExitMode(void)
 static void keebMainLoop(int64_t elapsedUs)
 {
     buttonEvt_t evt = {0};
+    bool drawlines = true;
     switch (kbTest->currState)
     {
         case MENU:
@@ -238,7 +241,6 @@ static void keebMainLoop(int64_t elapsedUs)
             drawMenuMania(kbTest->menu, kbTest->renderer, elapsedUs);
             break;
         case TYPING:
-            bool drawlines = true;
             while (checkButtonQueueWrapper(&evt))
             {
                 if (!textEntryInput(evt.down, evt.button))
@@ -308,6 +310,7 @@ static void kbMenuCb(const char* label, bool selected, uint32_t settingVal)
             textEntrySetNewEnterStyle(kbTest->enter);
             textEntrySetNewCapsStyle(kbTest->caps);
             textEntrySetMultiline(kbTest->multi);
+            textEntrySetPrompt(kbTest->prompt);
             if (kbTest->reset)
             {
                 strcpy(kbTest->typedText, "");
@@ -390,6 +393,19 @@ static void kbMenuCb(const char* label, bool selected, uint32_t settingVal)
                 setWarning(500, "Character count disabled");
             }
         }
+        else if (label == teMenuPrompt)
+        {
+            if (strlen(kbTest->prompt) > 1)
+            {
+                strcpy(kbTest->prompt, "");
+                setWarning(500, "Disabled text prompt");
+            }
+            else
+            {
+                strcpy(kbTest->prompt, "Text Prompt!");
+                setWarning(500, "Enabled sample text prompt");
+            }
+        }
         else if (label == teMenuReset)
         {
             kbTest->reset = !kbTest->reset;
@@ -443,6 +459,7 @@ static void reset()
     kbTest->caps        = false;
     kbTest->multi       = false;
     strcpy(kbTest->typedText, "");
+    strcpy(kbTest->prompt, "");
     textEntryInit(&kbTest->fnt[0], MAX_TEXT_LEN, kbTest->typedText);
 }
 

--- a/main/modes/test/keebTest/keebTest.c
+++ b/main/modes/test/keebTest/keebTest.c
@@ -101,6 +101,7 @@ static const char teMenuCaps[]         = "Caps Style";
 static const char teMenuMulti[]        = "Multiline";
 static const char teMenuCount[]        = "Char Count";
 static const char teMenuPrompt[]       = "Sample Prompt";
+static const char teMenuTypingMode[]   = "Mode: ";
 static const char teMenuReset[]        = "Reset String";
 static const char teMenuResetHard[]    = "Reset TextEntry";
 
@@ -112,19 +113,17 @@ static const char colorSettingLabel4[] = "Color: ";    // Shadowboxes
 static const int32_t colorSettingsValues[]
     = {c000, c500, c050, c005, c550, c505, c055, c555, c111, c222, c444, c433, c303};
 
-static const char* const colorSettingsOptions[] = {
-    "Black", "Red",       "Green",       "Blue",       "Yellow", "Magenta", "Cyan",
-    "White", "Dark gray", "Medium Gray", "Light Gray", "Pink",   "Purple",
-};
+static const char* const colorSettingsOptions[]
+    = {"Black", "Red",      "Green",    "Blue",     "Yellow", "Magenta", "Cyan",
+       "White", "Dk. gray", "Md. Gray", "Lt. Gray", "Pink",   "Purple"};
 
 static const int32_t fontSettingsValues[] = {0, 1, 2, 3};
 
-static const char* const fontSettingsOptions[] = {
-    "vga_ibm8",
-    "radiostars",
-    "rodin",
-    "righteous",
-};
+static const char* const fontSettingsOptions[] = {"vga_ibm8", "radiostars", "rodin", "righteous"};
+
+static const int32_t typingModeSettingsValues[] = {0, 1, 2, 3};
+
+static const char* const typingModeSettingsOptions[] = {"lower", "Shift", "CAPS", "P. Noun"};
 
 //==============================================================================
 // Variables
@@ -193,6 +192,8 @@ static void keebEnterMode(void)
     addSingleItemToMenu(kbTest->menu, teMenuMulti);
     addSingleItemToMenu(kbTest->menu, teMenuCount);
     addSingleItemToMenu(kbTest->menu, teMenuPrompt);
+    addSettingsOptionsItemToMenu(kbTest->menu, teMenuTypingMode, typingModeSettingsOptions, typingModeSettingsValues,
+                                 ARRAY_SIZE(typingModeSettingsValues), getScreensaverTimeSettingBounds(), 1);
     addSingleItemToMenu(kbTest->menu, teMenuReset);
     addSingleItemToMenu(kbTest->menu, teMenuResetHard);
 
@@ -230,7 +231,7 @@ static void keebExitMode(void)
 static void keebMainLoop(int64_t elapsedUs)
 {
     buttonEvt_t evt = {0};
-    bool drawlines = true;
+    bool drawlines  = true;
     switch (kbTest->currState)
     {
         case MENU:
@@ -314,6 +315,23 @@ static void kbMenuCb(const char* label, bool selected, uint32_t settingVal)
             if (kbTest->reset)
             {
                 strcpy(kbTest->typedText, "");
+            }
+            switch (kbTest->typingMode)
+            {
+                case 0:
+                    textEntrySetNoShiftMode();
+                    break;
+                case 1:
+                    textEntrySetShiftMode();
+                    break;
+                case 2:
+                    textEntrySetCapMode();
+                    break;
+                case 3:
+                    textEntrySetNounMode();
+                    break;
+                default:
+                    break;
             }
             // Switch state
             kbTest->currState = TYPING;
@@ -444,6 +462,10 @@ static void kbMenuCb(const char* label, bool selected, uint32_t settingVal)
     {
         kbTest->shadowColor = settingVal;
     }
+    if (label == teMenuTypingMode)
+    {
+        kbTest->typingMode = settingVal;
+    }
 }
 
 static void reset()
@@ -452,12 +474,13 @@ static void reset()
     kbTest->bckgrnd     = COLOR_BG;
     kbTest->bgColor     = c000;
     kbTest->textColor   = c555;
-    kbTest->empColor    = c555;
+    kbTest->empColor    = c500;
     kbTest->shadow      = true;
     kbTest->shadowColor = c111;
     kbTest->enter       = false;
     kbTest->caps        = false;
     kbTest->multi       = false;
+    kbTest->typingMode  = 1;
     strcpy(kbTest->typedText, "");
     strcpy(kbTest->prompt, "");
     textEntryInit(&kbTest->fnt[0], MAX_TEXT_LEN, kbTest->typedText);

--- a/main/modes/test/keebTest/keebTest.h
+++ b/main/modes/test/keebTest/keebTest.h
@@ -69,6 +69,7 @@ typedef struct
     bool count;
     bool reset;
     char prompt[16];
+    uint8_t typingMode;
 
     // Warnings
     char warningText[32];

--- a/main/modes/test/keebTest/keebTest.h
+++ b/main/modes/test/keebTest/keebTest.h
@@ -2,7 +2,7 @@
  * @file keebTest.h
  * @author Jeremy Stintzcum (jeremy.stintzcum@gmail.com)
  * @brief A mode designed to test keyboard variations in rapid succession
- * @version 1.0
+ * @version 1.1
  * @date 2024-07-06
  *
  * @copyright Copyright (c) 2024

--- a/main/modes/test/keebTest/keebTest.h
+++ b/main/modes/test/keebTest/keebTest.h
@@ -68,6 +68,7 @@ typedef struct
     bool multi;
     bool count;
     bool reset;
+    char prompt[16];
 
     // Warnings
     char warningText[32];

--- a/main/utils/textEntry.c
+++ b/main/utils/textEntry.c
@@ -9,7 +9,7 @@
  *
  * @param endH Where the keyboard ends
  * @param elapsedUs How many ms have elapsed since last time function was called
- * @return int16_t Top of textbox for nex element
+ * @return int16_t Top of textbox for next element
  */
 static int16_t _drawStr(int16_t endH, int64_t elapsedUs);
 

--- a/main/utils/textEntry.c
+++ b/main/utils/textEntry.c
@@ -206,7 +206,7 @@ bool textEntryDraw(int64_t elapsedUs)
     }
     // Draw an indicator for the current key modifier
     _drawTypeMode();
-    // Draw the rest of the fucking owl
+    // Draw the rest of the owl
     _drawPrompt(_drawStr(_drawKeyboard(), elapsedUs));
     return true;
 }

--- a/main/utils/textEntry.h
+++ b/main/utils/textEntry.h
@@ -86,6 +86,7 @@
  *     {
  *         // Text entry is done, createdString contains the text and can be used elsewhere
  *     }
+ *     // Draw backgrounds for transparent mode here.
  *     textEntryDraw(elapsedUs);
  * }
  * \endcode

--- a/main/utils/textEntry.h
+++ b/main/utils/textEntry.h
@@ -21,6 +21,11 @@
  *                                                           background
  * - textEntrySetNewEnterStyle(bool newStyle): Sets the style to old (false) or new (true)
  * - textEntrySetNewCapsStyle(bool newStyle): Sets the style to old (false) or new (true)
+ * - textEntrySetPrompt(char *prompt): Sets a string to be displayed over the text box as a prompt to the user
+ * - textEntrySetCapMode(): Set the starting mode to Capslock
+ * - textEntrySetNoShiftMode(): Set the current mode to lowercase text
+ * - textEntrySetShiftMode(): Set the current mode to shift
+ * - textEntrySetNounMode(): Set current mode to porper noun, which capitalizes the first letter after a space.
  *
  * The text entry is re-drawn from scratch every cycle. The above commands can be run between cycles if desired, though
  * it is strongly discouraged to keep the text entry easy for the end user to navigate and utilize.
@@ -46,6 +51,7 @@
  * int strLen = 32;
  * char createdString[strlen];
  * wsg bg_test;
+ * const char promptStr[] "Enter your name:";
  *
  * // Text Entry initialization
  * textEntryInit(&fnt, strLen, kbTest->typedText);
@@ -57,15 +63,17 @@
  * textEntrySetEmphasisColor(c500);
  * textEntrySetShadowboxColor(c111);
  *
- * // WSG background, pink shadowboxes, and a new font
+ * // WSG background, pink shadowboxes, a new font and a prompt string
  * textEntrySetBgWsg(&bg_test);
  * textEntrySetShadowboxColor(true, c433);
  * textEntrySetFont(&fnt2);
+ * textEntrySetPrompt(promptStr);
  *
- * // Transparent BG with caps lock and enter variations
+ * // Transparent BG with caps lock and enter variations, and with the starting mode set to "Proper noun"
  * textEntrySetBGTransparent();
  * textEntrySetNewCapsStyle(true);
  * textEntrySetNewEnterStyle(true);
+ * textEntrySetNounMode();
  *
  * main loop(int64_t elapsedUs)
  * {
@@ -119,6 +127,7 @@ typedef enum
     NO_SHIFT,
     SHIFT,
     CAPS_LOCK,
+    PROPER_NOUN,
     SPECIAL_DONE
 } keyModifier_t;
 
@@ -253,11 +262,31 @@ void textEntrySoftReset(void);
 
 /**
  * @brief Sets the prompt text to be displayed. Use an empty string ("") to disable.
- * 
+ *
  * @param prompt Text string to use
  */
-void textEntrySetPrompt(char *prompt);
+void textEntrySetPrompt(char* prompt);
 
-// TODO: Start with Caps active
+/**
+ * @brief Sets the starting mode to capslock
+ *
+ */
+void textEntrySetCapMode(void);
 
-// TODO: Automatically capitalize text (Proper name mode)
+/**
+ * @brief Sets the starting mode to lowercase text
+ *
+ */
+void textEntrySetNoShiftMode(void);
+
+/**
+ * @brief Sets the starting mode to Shift, does one capital letter
+ *
+ */
+void textEntrySetShiftMode(void);
+
+/**
+ * @brief Sets the starting mode to Porper Nouns (Auto capitalizes first letter after a space)
+ *
+ */
+void textEntrySetNounMode(void);

--- a/main/utils/textEntry.h
+++ b/main/utils/textEntry.h
@@ -250,3 +250,14 @@ void textEntrySetMultiline(bool multiline);
  *
  */
 void textEntrySoftReset(void);
+
+/**
+ * @brief Sets the prompt text to be displayed. Use an empty string ("") to disable.
+ * 
+ * @param prompt Text string to use
+ */
+void textEntrySetPrompt(char *prompt);
+
+// TODO: Start with Caps active
+
+// TODO: Automatically capitalize text (Proper name mode)


### PR DESCRIPTION
### Description

textEntry.h now supports a prompt and setting the initial text entry mode.

### Test Instructions

Tested in emulator.
Tested on swadge hardware.

### Ticket Links

#251 

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
