### PR TITLE
Fixed text capitialization condition to allow Capslock to work

### DIFF
--- a/main/utils/textEntry.c
+++ b/main/utils/textEntry.c
@@ -546,9 +546,8 @@ static int16_t _drawKeyboard()
     int row = 0;
     char c;
     int stringLen = strlen(texString);
-    bool noun     = (texString[stringLen - 1] == KEY_SPACE || stringLen == 0) ? false : true;
     const char* s;
-    if (keyMod == NO_SHIFT || noun)
+    if (keyMod == NO_SHIFT || (keyMod == PROPER_NOUN && !(texString[stringLen - 1] == KEY_SPACE || stringLen == 0)))
     {
         s = keyboard_lower;
     }


### PR DESCRIPTION
### Description

Fixed issue #253, Capslock and shift not functioning as expected.

### Test Instructions

1. Run ./swadge-emulator -m "Keyboard Test"
2. Enter text entry
3. Type in at least one character
4. Set caps mode, set shift mode, observe how the text does not capitalize
   
### Ticket Links

#253 

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
