### PR TITLE
Standalone OSX Build Fixes

### DIFF
--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -125,14 +125,23 @@ jobs:
         delete-merged: true
 
     ## Firmware
+    - name: Restore IDF Cache
+      id: cache-esp-idf
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{ env.HOME }}/.espressif
+          ${{ runner.temp }}/esp-idf
+        key: esp-idf-cache-${{ matrix.os }}
+
     - name: Set up the IDF
-      if: matrix.firmware && matrix.family == 'windows'
+      if: steps.cache-esp-idf.outputs.cache-hit != 'true' && matrix.firmware && matrix.family == 'windows'
       run: |
         git clone -b v5.2.1 --recurse-submodules https://github.com/espressif/esp-idf.git ${{ runner.temp }}/esp-idf -j2
         ${{ runner.temp }}/esp-idf/install.ps1
 
     - name: Set up the IDF
-      if: matrix.firmware && matrix.family != 'windows'
+      if: steps.cache-esp-idf.outputs.cache-hit != 'true' && matrix.firmware && matrix.family != 'windows'
       run: |
         git clone -b v5.2.1 --recurse-submodules https://github.com/espressif/esp-idf.git ${{ runner.temp }}/esp-idf -j2
         ${{ runner.temp }}/esp-idf/install.sh

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -24,24 +24,29 @@ jobs:
             emulator: true
             firmware: true
             emu_binary: swadge_emulator.exe
+            # TODO: What variable can we use to not hardcode this???
+            idf_install: C:\Users\runneradmin\.espressif
           - os: osx-arm
             runner: macos-latest
             family: osx
             emulator: true
             firmware: false
             emu_binary: swadge_emulator
+            idf_install: ~/.espressif
           - os: osx-intel
             runner: macos-13
             family: osx
             emulator: true
             firmware: false
             emu_binary: swadge_emulator
+            idf_install: ~/.espressif
           - os: linux
             runner: ubuntu-latest
             family: linux
             emulator: true
             firmware: false
             emu_binary: swadge_emulator
+            idf_install: ~/.espressif
 
     runs-on: ${{ matrix.runner }}
     steps:
@@ -123,7 +128,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: |
-          ${{ env.HOME }}/.espressif
+          ${{ matrix.idf_install }}
           ${{ runner.temp }}/esp-idf
         key: esp-idf-cache-${{ matrix.os }}
 

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -64,7 +64,7 @@ jobs:
       if: matrix.family == 'windows'
       uses: msys2/setup-msys2@v2
       with:
-        msystem: MINGW64
+        msystem: UCRT64
         install: >-
           base-devel
           gcc

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -16,7 +16,7 @@ jobs:
   Build-Firmware-And-Emulator:
     strategy:
       matrix:
-        os: [ windows, osx-arm, osx-intel ]
+        os: [ windows, osx-arm, osx-intel, linux ]
         include:
           - os: windows
             runner: windows-latest
@@ -33,6 +33,12 @@ jobs:
           - os: osx-intel
             runner: macos-13
             family: osx
+            emulator: true
+            firmware: false
+            emu_binary: swadge_emulator
+          - os: linux
+            runner: ubuntu-latest
+            family: linux
             emulator: true
             firmware: false
             emu_binary: swadge_emulator
@@ -64,6 +70,11 @@ jobs:
       run: |
         brew install xquartz libxinerama clang-format cppcheck wget doxygen cmake graphviz
 
+    - name: Install apt packages
+      if: matrix.family == 'linux'
+      run: |
+        sudo apt install build-essential xorg-dev libx11-dev libxinerama-dev libxext-dev mesa-common-dev libglu1-mesa-dev libasound2-dev libpulse-dev git libasan8 cppcheck python3 python3-pip python3-venv cmake libusb-1.0-0-dev lcov gdb graphviz
+
     #### Platform-specific Emulator Builds
     - name: Compile the Emulator
       if: matrix.emulator && matrix.family == 'windows'
@@ -72,7 +83,7 @@ jobs:
         make -j2
 
     - name: Compile the Emulator
-      if: matrix.emulator && matrix.family == 'osx'
+      if: matrix.emulator && matrix.family != 'windows'
       run: |
         make -j3
 
@@ -107,7 +118,7 @@ jobs:
 
     ## Firmware
     - name: Set up the IDF
-      if: matrix.firmware
+      if: matrix.firmware && matrix.family == 'windows'
       run: |
         git clone -b v5.2.1 --recurse-submodules https://github.com/espressif/esp-idf.git ${{ runner.temp }}/esp-idf -j2
         ${{ runner.temp }}/esp-idf/install.ps1

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -62,17 +62,8 @@ jobs:
     #### Platform-specific Dependencies
     - name: Install msys64 packages
       if: matrix.family == 'windows'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: UCRT64
-        install: >-
-          base-devel
-          gcc
-          gdb
-          zip
-          mingw-w64-x86_64-graphviz
-          mingw-w64-x86_64-cppcheck
-          doxygen
+      run: |
+        C:\msys64\usr\bin\bash -lc 'pacman --noconfirm -S base-devel gcc gdb zip mingw-w64-x86_64-graphviz mingw-w64-x86_64-cppcheck doxygen'
 
     - name: Install homebrew packages
       if: matrix.family == 'osx'

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -119,6 +119,7 @@ jobs:
     ## Firmware
     - name: Restore IDF Cache
       id: cache-esp-idf
+      if: matrix.firmware
       uses: actions/cache@v3
       with:
         path: |

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - midi-synth-platform-midi
   pull_request:
     branches:
       - main

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -61,9 +61,17 @@ jobs:
 
     #### Platform-specific Dependencies
     - name: Install msys64 packages
-      if: matrix.family == 'windows'
-      run: |
-        C:\msys64\usr\bin\bash -lc 'pacman --noconfirm -S base-devel gcc gdb zip mingw-w64-x86_64-graphviz mingw-w64-x86_64-cppcheck doxygen'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{matrix.sys}}
+        install: >-
+          base-devel
+          gcc
+          gdb
+          zip
+          mingw-w64-x86_64-graphviz
+          mingw-w64-x86_64-cppcheck
+          doxygen
 
     - name: Install homebrew packages
       if: matrix.family == 'osx'

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - main
+      - midi-synth-platform-midi
   pull_request:
-    branches:    
+    branches:
       - main
 
 env:
@@ -14,58 +15,125 @@ env:
 
 jobs:
   Build-Firmware-And-Emulator:
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        os: [ windows, osx-arm, osx-intel ]
+        include:
+          - os: windows
+            runner: windows-latest
+            family: windows
+            emulator: true
+            firmware: true
+            emu_binary: swadge_emulator.exe
+          - os: osx-arm
+            runner: macos-latest
+            family: osx
+            emulator: true
+            firmware: false
+            emu_binary: swadge_emulator
+          - os: osx-intel
+            runner: macos-13
+            family: osx
+            emulator: true
+            firmware: false
+            emu_binary: swadge_emulator
+
+    runs-on: ${{ matrix.runner }}
     steps:
 
     # - name: Debug print event
     #   run: echo '${{ toJSON(github.event) }}'
 
+    #### Basic Steps
     - name: Check out repository code
       uses: actions/checkout@v4.1.4
       with:
         submodules: recursive
-      
+
     - name: Create a version file
       run: |
-        printf "Commit: https://github.com/AEFeinstein/Super-2024-Swadge-FW/commit/$(git rev-parse HEAD) \nBuilt at: $(date)" >> version.txt
+        printf "Commit: https://github.com/AEFeinstein/Super-2024-Swadge-FW/commit/$(git rev-parse HEAD) \nBuilt on ${{ matrix.os }} at: $(date)" >> version.txt
 
+    #### Platform-specific Dependencies
     - name: Install msys64 packages
+      if: matrix.family == 'windows'
       run: |
         C:\msys64\usr\bin\bash -lc 'pacman --noconfirm -S base-devel gcc gdb zip mingw-w64-x86_64-graphviz mingw-w64-x86_64-cppcheck doxygen'
 
+    - name: Install homebrew packages
+      if: matrix.family == 'osx'
+      run: |
+        brew install xquartz libxinerama clang-format cppcheck wget doxygen cmake graphviz
+
+    #### Platform-specific Emulator Builds
     - name: Compile the Emulator
+      if: matrix.emulator && matrix.family == 'windows'
       run: |
         $env:path = $env:path.Insert($env:path.ToLower().IndexOf("c:\windows\system32"), "C:\msys64\mingw64\bin;C:\msys64\usr\bin;")
         make -j2
 
-    - name: Upload Emulator EXE
+    - name: Compile the Emulator
+      if: matrix.emulator && matrix.family == 'osx'
+      run: |
+        make -j3
+
+    #### Generic Emulator Upload
+    - name: Upload Emulator Binary
+      if: matrix.emulator
       uses: actions/upload-artifact@v4.3.3
       with:
-        name: ${{ env.EMULATOR_ARTIFACT }}-exe
+        name: ${{ env.EMULATOR_ARTIFACT }}-${{ matrix.os }}-exe
         path: |
-          swadge_emulator.exe
+          ${{ matrix.emu_binary }}
           spiffs_image
           version.txt
 
+    ## Platform-specific Emulator Uploads
     - name: Upload Emulator DLL
+      if: matrix.emulator && matrix.family == 'windows'
       uses: actions/upload-artifact@v4.3.3
       with:
-        name: ${{ env.EMULATOR_ARTIFACT }}-dll
+        name: ${{ env.EMULATOR_ARTIFACT }}-${{ matrix.os }}-dll
         path: |
           C:\msys64\mingw64\bin\libwinpthread-1.dll
 
+    # Merge all emulator artifacts for each OS into one
+    - name: Merge Emulator Artifacts
+      if: matrix.emulator
+      uses: actions/upload-artifact/merge@v4.3.3
+      with:
+        name: ${{ env.EMULATOR_ARTIFACT }}-${{ matrix.os }}
+        pattern: ${{ env.EMULATOR_ARTIFACT }}-${{ matrix.os }}-*
+        delete-merged: true
+
+    ## Firmware
     - name: Set up the IDF
+      if: matrix.firmware
       run: |
         git clone -b v5.2.1 --recurse-submodules https://github.com/espressif/esp-idf.git ${{ runner.temp }}/esp-idf -j2
         ${{ runner.temp }}/esp-idf/install.ps1
- 
+
+    - name: Set up the IDF
+      if: matrix.firmware && matrix.family != 'windows'
+      run: |
+        git clone -b v5.2.1 --recurse-submodules https://github.com/espressif/esp-idf.git ${{ runner.temp }}/esp-idf -j2
+        ${{ runner.temp }}/esp-idf/install.sh
+
     - name: Compile the firmware
+      if: matrix.firmware && matrix.family == 'windows'
       run: |
         $env:path = $env:path.Insert($env:path.ToLower().IndexOf("c:\windows\system32"), "C:\msys64\mingw64\bin;C:\msys64\usr\bin;")
         ${{ runner.temp }}/esp-idf/export.ps1
         idf.py build dfu
 
+    - name: Compile the firmware
+      if: matrix.firmware && matrix.family != 'windows'
+      run: |
+        ${{ runner.temp }}/esp-idf/export.sh
+        idf.py build dfu
+
     - name: Add firmware, bootloader, partition table, version, and flasher files to firmware artifact
+      if: matrix.firmware
       uses: actions/upload-artifact@v4.3.3
       with:
         name: ${{ env.FIRMWARE_ARTIFACT }}
@@ -92,14 +160,3 @@ jobs:
         slack-message: "*Build Result*: ${{ job.status }}\n*Author*: ${{ github.event.head_commit.author.username }}\n*Head Commit Message*:\n```\n${{ github.event.head_commit.message }}\n```\n*Comparison*: ${{ github.event.compare }}\n*Artifacts*: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       env:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-
-  Merge-Emulator-Artifacts:
-    runs-on: windows-latest
-    needs: Build-Firmware-And-Emulator
-    steps:
-      - name: Merge Emulator Artifacts
-        uses: actions/upload-artifact/merge@v4.3.3
-        with:
-          name: ${{ env.EMULATOR_ARTIFACT }}
-          pattern: ${{ env.EMULATOR_ARTIFACT }}-*
-          delete-merged: true

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -64,7 +64,7 @@ jobs:
       if: matrix.family == 'windows'
       uses: msys2/setup-msys2@v2
       with:
-        msystem: ${{matrix.sys}}
+        msystem: MINGW64
         install: >-
           base-devel
           gcc

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -61,6 +61,7 @@ jobs:
 
     #### Platform-specific Dependencies
     - name: Install msys64 packages
+      if: matrix.family == 'windows'
       uses: msys2/setup-msys2@v2
       with:
         msystem: ${{matrix.sys}}

--- a/emulator/src/emu_main.c
+++ b/emulator/src/emu_main.c
@@ -72,7 +72,7 @@
 #include "CNFG.h"
 
 #define CNFA_IMPLEMENTATION
-#if defined(__linux) || defined(__linux__) || defined(linux) || defined(__LINUX__) || defined(__APPLE__)
+#if defined(__linux) || defined(__linux__) || defined(linux) || defined(__LINUX__)
     #define PULSEAUDIO
 #endif
 #include "CNFA.h"

--- a/emulator/src/emu_main.c
+++ b/emulator/src/emu_main.c
@@ -11,7 +11,6 @@
         #define _GNU_SOURCE
     #endif
     #include <dlfcn.h>
-    #include <link.h>
 #endif
 #include <time.h>
 

--- a/main/utils/textEntry.c
+++ b/main/utils/textEntry.c
@@ -606,9 +606,11 @@ static int16_t _drawKeyboard()
                     width = _drawEnter(posX, posY, textColor);
                     break;
                 default:
+                {
                     // Just draw the char
                     char sts[] = {c, 0};
                     drawText(activeFont, textColor, sts, posX, posY);
+                }
             }
             if (col == selX && row == selY)
             {

--- a/makefile
+++ b/makefile
@@ -109,9 +109,7 @@ endif
 ifeq ($(HOST_OS),Linux)
 CFLAGS += \
 	-fsanitize=address \
-	-fsanitize=bounds-strict \
-	-fno-omit-frame-pointer
-
+	-fsanitize=bounds-strict
 ENABLE_GCOV=false
 
 ifeq ($(ENABLE_GCOV),true)

--- a/makefile
+++ b/makefile
@@ -263,6 +263,9 @@ ifneq ($(HOST_OS),Darwin)
 LIBRARY_FLAGS += \
 	-static-libgcc \
 	-static-libstdc++
+else
+LIBRARY_FLAGS += \
+	-framework AudioToolbox
 endif
 
 ifeq ($(HOST_OS),Linux)

--- a/makefile
+++ b/makefile
@@ -81,7 +81,6 @@ INC = $(patsubst %, -I%, $(INC_DIRS) )
 CFLAGS = \
 	-c \
 	-g \
-	-static-libstdc++ \
 	-fdiagnostics-color=always \
 	-ffunction-sections \
 	-fdata-sections \
@@ -96,8 +95,10 @@ ifneq ($(HOST_OS),Darwin)
 # Incompatible flags for clang on MacOS
 CFLAGS += \
 	-static-libgcc \
+	-static-libstdc++ \
 	-fstrict-volatile-bitfields \
-	-fno-tree-switch-conversion
+	-fno-tree-switch-conversion \
+	-fno-omit-frame-pointer
 else
 # Required for OpenGL and some other libraries
 CFLAGS += \
@@ -129,15 +130,13 @@ CFLAGS_WARNINGS = \
 	-Wno-unused-parameter \
 	-Wno-sign-compare \
 	-Wno-enum-conversion \
-	-Wno-error=unused-but-set-variable \
-	-Wno-old-style-declaration
+	-Wno-error=unused-but-set-variable
 
 # These are warning flags that I like
 CFLAGS_WARNINGS_EXTRA = \
 	-Wundef \
 	-Wformat=2 \
 	-Winvalid-pch \
-	-Wlogical-op \
 	-Wmissing-format-attribute \
 	-Wmissing-include-dirs \
 	-Wpointer-arith \
@@ -145,7 +144,6 @@ CFLAGS_WARNINGS_EXTRA = \
 	-Wuninitialized \
 	-Wshadow \
 	-Wredundant-decls \
-	-Wjump-misses-init \
 	-Wswitch \
 	-Wcast-align \
 	-Wformat-nonliteral \
@@ -162,6 +160,16 @@ CFLAGS_WARNINGS_EXTRA = \
 #	-Wconversion \
 #	-Wsign-conversion \
 #	-Wdouble-promotion
+
+ifneq ($(HOST_OS),Darwin)
+# Incompatible warnings for clang on MacOS
+CFLAGS_WARNINGS += \
+	-Wno-old-style-declaration
+
+CFLAGS_WARNINGS_EXTRA += \
+	-Wlogical-op \
+	-Wjump-misses-init
+endif
 
 ################################################################################
 # Defines
@@ -248,13 +256,13 @@ endif
 
 # This combines the flags for the linker to find and use libraries
 LIBRARY_FLAGS = $(patsubst %, -L%, $(LIB_DIRS)) $(patsubst %, -l%, $(LIBS)) \
-	-static-libstdc++ \
 	-ggdb
 
 # Incompatible flags for clang on MacOS
 ifneq ($(HOST_OS),Darwin)
 LIBRARY_FLAGS += \
-	-static-libgcc
+	-static-libgcc \
+	-static-libstdc++
 endif
 
 ifeq ($(HOST_OS),Linux)
@@ -387,7 +395,7 @@ CPPCHECK_DIRS= \
 CPPCHECK_IGNORE= \
 	$(shell $(FIND) emulator/src-lib -type f) \
 	$(shell $(FIND) main/asset_loaders -type f -iname "*heatshrink*")
-	
+
 CPPCHECK_IGNORE_FLAGS = $(patsubst %,-i%, $(CPPCHECK_IGNORE))
 
 cppcheck:

--- a/makefile
+++ b/makefile
@@ -243,7 +243,7 @@ ifeq ($(HOST_OS),Linux)
     LIBS = m X11 asound pulse rt GL GLX pthread Xext Xinerama
 endif
 ifeq ($(HOST_OS),Darwin)
-    LIBS = m X11 GL pulse pthread Xext Xinerama
+    LIBS = m X11 GL pthread Xext Xinerama
 endif
 
 # These are directories to look for library files in

--- a/tools/spiffs_file_preprocessor/src/raw_processor.c
+++ b/tools/spiffs_file_preprocessor/src/raw_processor.c
@@ -17,7 +17,7 @@ void process_raw(const char* inFile, const char* outDir, const char* outExt)
 
     // Change the file extension
     char* dotPtr = strrchr(outFilePath, '.');
-    strncpy(&dotPtr[1], outExt, sizeof(outFilePath) - (dotPtr - outFilePath));
+    strncpy(&dotPtr[1], outExt, sizeof(outFilePath) - (dotPtr - outFilePath) - 1);
 
     if (doesFileExist(outFilePath))
     {


### PR DESCRIPTION
### Description

Contains standalone fixes for OSX from the midi-synth-platform-midi branch.

### Test Instructions

Tested on the midi-synth-platform-midi branch and with an updated workflow that builds for OSX also.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
