### PR TITLE
CNFS - Use file references where it makes sense.

### DIFF
--- a/main/asset_loaders/fs_font.c
+++ b/main/asset_loaders/fs_font.c
@@ -34,7 +34,7 @@ bool loadFont(const char* name, font_t* font, bool spiRam)
     size_t bufIdx = 0;
     uint8_t chIdx = 0;
     size_t sz;
-    uint8_t* buf = cnfsReadFile(name, &sz, true);
+    uint8_t* buf = cnfsGetFile(name, &sz);
     if (NULL == buf)
     {
         ESP_LOGE("FONT", "Failed to read %s", name);
@@ -76,9 +76,6 @@ bool loadFont(const char* name, font_t* font, bool spiRam)
         font->chars[chIdx].bitmap  = NULL;
         font->chars[chIdx++].width = 0;
     }
-
-    // Free the read data
-    free(buf);
 
     return true;
 }

--- a/main/asset_loaders/heatshrink_helper.c
+++ b/main/asset_loaders/heatshrink_helper.c
@@ -28,7 +28,7 @@ uint8_t* readHeatshrinkFile(const char* fname, uint32_t* outsize, bool readToSpi
 {
     // Read WSG from file
     size_t sz;
-    uint8_t* buf = cnfsReadFile(fname, &sz, readToSpiRam);
+    uint8_t* buf = cnfsGetFile(fname, &sz);
     if (NULL == buf)
     {
         ESP_LOGE("WSG", "Failed to read %s", fname);
@@ -69,7 +69,6 @@ uint8_t* readHeatshrinkFile(const char* fname, uint32_t* outsize, bool readToSpi
             ESP_LOGE("WSG", "Failed to read %s fault on decode", fname);
             heatshrink_decoder_finish(hsd);
             heatshrink_decoder_free(hsd);
-            free(buf);
             free(decompressedBuf);
             return 0;
         }
@@ -91,8 +90,6 @@ uint8_t* readHeatshrinkFile(const char* fname, uint32_t* outsize, bool readToSpi
     // All done decoding
     heatshrink_decoder_finish(hsd);
     heatshrink_decoder_free(hsd);
-    // Free the bytes read from the file
-    free(buf);
 
     // Return the decompressed bytes
     return decompressedBuf;

--- a/main/utils/cnfs.h
+++ b/main/utils/cnfs.h
@@ -14,6 +14,8 @@
  *
  * cnfsReadFile() may be used to read a file straight from cnfs, but this probably should not be done directly.
  *
+ * cnfsGetFile() gets a reference to the file in flash, to obviate need to "load it into RAM"
+ *
  * Each asset type has it's own file loader which handles things like decompression if the asset type is compressed,
  * and writing values from the read file into a convenient struct. The loader functions are:
  *  - loadFont() & freeFont() - Load font assets from CNFS to draw text to the display
@@ -55,6 +57,7 @@
 
 bool initCnfs(void);
 bool deinitCnfs(void);
+const uint8_t* cnfsGetFile(const char* fname, size_t* flen);
 uint8_t* cnfsReadFile(const char* fname, size_t* outsize, bool readToSpiRam);
 
 #endif


### PR DESCRIPTION
### Description

This change lets you load files without needing to copy their contents.

### Test Instructions

This change should be transparent but improve performance.

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
