### PR TITLE
Fix delay on accelerometer bringup. Found out we needed more time.

### DIFF
--- a/components/hdw-imu/hdw-imu.c
+++ b/components/hdw-imu/hdw-imu.c
@@ -304,7 +304,12 @@ do_retry:
     // Enable access
     LSM6DSLSet(LSM6DSL_FUNC_CFG_ACCESS, 0x20);
     LSM6DSLSet(LSM6DSL_CTRL3_C, 0x81); // Force reset
-    esp_rom_delay_us(100);
+
+    // Found out we have to delay here.
+    // 1000us = not long enough
+    // 1100us = long enough
+    // 1200us = be safe.
+    esp_rom_delay_us(1200);
     LSM6DSLSet(LSM6DSL_CTRL3_C, 0x44); // unforce reset
 
     uint8_t who = 0xaa;


### PR DESCRIPTION
### Description

Accel was being brought up too quickly potentially having incorrect settings to boot.

### Test Instructions

Experimentally by looking at the I2C bus

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
