### PR TITLE
Create snapshot release with downloads when merging into main

### DIFF
--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -24,10 +24,10 @@ jobs:
             family: windows
             emulator: true
             firmware: true
-            emu_artifacts: |
-              swadge_emulator.exe
-              version.txt
-              C:\msys64\mingw64\bin\libwinpthread-1.dll
+            emu_artifacts:
+              - swadge_emulator.exe
+              - version.txt
+              - C:\msys64\mingw64\bin\libwinpthread-1.dll
             # TODO: What variable can we use to not hardcode this???
             idf_install: C:\Users\runneradmin\.espressif
           - os: osx-arm
@@ -35,27 +35,27 @@ jobs:
             family: osx
             emulator: true
             firmware: false
-            emu_artifacts: |
-              SwadgeEmulator.app
-              version.txt
+            emu_artifacts:
+              - SwadgeEmulator.app
+              - version.txt
             idf_install: ~/.espressif
           - os: osx-intel
             runner: macos-13
             family: osx
             emulator: true
             firmware: false
-            emu_artifacts: |
-              SwadgeEmulator.app
-              version.txt
+            emu_artifacts:
+              - SwadgeEmulator.app
+              - version.txt
             idf_install: ~/.espressif
           - os: linux
             runner: ubuntu-latest
             family: linux
             emulator: true
             firmware: false
-            emu_artifacts: |
-              swadge_emulator
-              version.txt
+            emu_artifacts:
+              - swadge_emulator
+              - version.txt
             idf_install: ~/.espressif
 
     runs-on: ${{ matrix.runner }}
@@ -173,7 +173,7 @@ jobs:
       if: matrix.emulator
       run: |
         find .
-        zip -r SwadgeEmulator.zip ${{ join(matrix.emu_artifacts) }}
+        zip -r SwadgeEmulator.zip ${{ join(matrix.emu_artifacts, ' ') }}
 
     #### Generic Emulator Upload
     - name: Upload Emulator Binary

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -232,7 +232,9 @@ jobs:
     needs: Build-Firmware-And-Emulator
     steps:
     - name: Post to a Slack channel
-      if: (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      if: ((github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')) && ${{ env.SLACK_BOT_TOKEN != '' }}
       id: slack
       uses: slackapi/slack-github-action@v1.26.0
       with:
@@ -242,5 +244,3 @@ jobs:
         channel-id: 'C6FNXU6KX'
         # For posting a simple plain text message
         slack-message: "*Build Result*: ${{ job.status }}\n*Author*: ${{ github.event.head_commit.author.username }}\n*Head Commit Message*:\n```\n${{ github.event.head_commit.message }}\n```\n*Comparison*: ${{ github.event.compare }}\n*Artifacts*: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-      env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -173,9 +173,7 @@ jobs:
     - name: Copy libwinpthread DLL
       if: matrix.emulator && matrix.family == 'windows'
       run: |
-        echo "${{ steps.install-msys64.outputs.msys2-location }}"
-        find ${{ steps.install-msys64.outputs.msys2-location }} -iname '*.dll'
-        cp ${{ steps.install-msys64.outputs.msys2-location }}\bin\libwinpthread-1.dll libwinpthread-1.dll
+        cp C:\msys64\bin\libwinpthread-1.dll libwinpthread-1.dll
 
     - name: Create Emulator zip
       if: matrix.emulator && matrix.family != 'windows'

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -27,7 +27,7 @@ jobs:
             emu_artifacts:
               - swadge_emulator.exe
               - version.txt
-              - C:\msys64\mingw64\bin\libwinpthread-1.dll
+              - libwinpthread-1.dll
             # TODO: What variable can we use to not hardcode this???
             idf_install: C:\Users\runneradmin\.espressif
           - os: osx-arm
@@ -168,6 +168,11 @@ jobs:
       if: matrix.emulator && matrix.family == 'osx'
       run: |
         make SwadgeEmulator.app
+
+    - name: Copy libwinpthread DLL
+      if: matrix.emulator && matrix.family == 'windows'
+      run: |
+        cp C:\msys64\mingw64\bin\libwinpthread-1.dll libwinpthread-1.dll
 
     - name: Create Emulator zip
       if: matrix.emulator && matrix.family != 'windows'

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -212,6 +212,10 @@ jobs:
         for os in osx-arm osx-intel linux windows ; do
         mv ${{ env.EMULATOR_ARTIFACT }}-${os}/SwadgeEmulator.zip SwadgeEmulator-${os}.zip
         done
+        mkdir firmware-zip
+        find ${{ env.FIRMWARE_ARTIFACT }}/ -type f -exec mv {} firmware-zip/ \;
+        cd firmware-zip
+        zip ../${{ env.FIRMWARE_ARTIFACT }}.zip *
 
     - name: Create release for latest artifacts
       if: (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')
@@ -221,7 +225,7 @@ jobs:
         prerelease: true
         allowUpdates: true
         replacesArtifacts: true
-        artifacts: "${{ env.FIRMWARE_ARTIFACT }}/*,SwadgeEmulator-*"
+        artifacts: "${{ env.FIRMWARE_ARTIFACT }}.zip,SwadgeEmulator-*"
         commit: main
         tag: snapshot
         name: Snapshot

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -174,6 +174,7 @@ jobs:
       if: matrix.emulator && matrix.family == 'windows'
       run: |
         echo "${{ steps.install-msys64.outputs.msys2-location }}"
+        find ${{ steps.install-msys64.outputs.msys2-location }} -iname '*.dll'
         cp ${{ steps.install-msys64.outputs.msys2-location }}\bin\libwinpthread-1.dll libwinpthread-1.dll
 
     - name: Create Emulator zip

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -24,21 +24,27 @@ jobs:
             family: osx
             emulator: true
             firmware: false
-            emu_binary: SwadgeEmulator.zip
+            emu_artifacts: |
+              SwadgeEmulator.app
+              version.txt
             idf_install: ~/.espressif
           - os: osx-intel
             runner: macos-13
             family: osx
             emulator: true
             firmware: false
-            emu_binary: SwadgeEmulator.zip
+            emu_artifacts: |
+              SwadgeEmulator.app
+              version.txt
             idf_install: ~/.espressif
           - os: linux
             runner: ubuntu-latest
             family: linux
             emulator: true
             firmware: false
-            emu_binary: swadge_emulator
+            emu_artifacts: |
+              swadge_emulator
+              version.txt
             idf_install: ~/.espressif
 
     runs-on: ${{ matrix.runner }}
@@ -73,52 +79,6 @@ jobs:
       if: matrix.family == 'linux'
       run: |
         sudo apt install build-essential xorg-dev libx11-dev libxinerama-dev libxext-dev mesa-common-dev libglu1-mesa-dev libasound2-dev libpulse-dev git libasan8 cppcheck python3 python3-pip python3-venv cmake libusb-1.0-0-dev lcov gdb graphviz
-
-    #### Platform-specific Emulator Builds
-    - name: Compile the Emulator
-      if: matrix.emulator && matrix.family == 'windows'
-      run: |
-        $env:path = $env:path.Insert($env:path.ToLower().IndexOf("c:\windows\system32"), "C:\msys64\mingw64\bin;C:\msys64\usr\bin;")
-        make -j2
-
-    - name: Compile the Emulator
-      if: matrix.emulator && matrix.family != 'windows'
-      run: |
-        make -j3
-
-    - name: Build OSX Bundle
-      if: matrix.emulator && matrix.family == 'osx'
-      run: |
-        make SwadgeEmulator.app
-        zip -r SwadgeEmulator.zip SwadgeEmulator.app
-
-    #### Generic Emulator Upload
-    - name: Upload Emulator Binary
-      if: matrix.emulator
-      uses: actions/upload-artifact@v4.3.3
-      with:
-        name: ${{ env.EMULATOR_ARTIFACT }}-${{ matrix.os }}-exe
-        path: |
-          ${{ matrix.emu_binary }}
-          version.txt
-
-    ## Platform-specific Emulator Uploads
-    - name: Upload Emulator DLL
-      if: matrix.emulator && matrix.family == 'windows'
-      uses: actions/upload-artifact@v4.3.3
-      with:
-        name: ${{ env.EMULATOR_ARTIFACT }}-${{ matrix.os }}-dll
-        path: |
-          C:\msys64\mingw64\bin\libwinpthread-1.dll
-
-    # Merge all emulator artifacts for each OS into one
-    - name: Merge Emulator Artifacts
-      if: matrix.emulator
-      uses: actions/upload-artifact/merge@v4.3.3
-      with:
-        name: ${{ env.EMULATOR_ARTIFACT }}-${{ matrix.os }}
-        pattern: ${{ env.EMULATOR_ARTIFACT }}-${{ matrix.os }}-*
-        delete-merged: true
 
     ## Firmware
     - name: Restore IDF Cache
@@ -170,6 +130,36 @@ jobs:
           build/partition_table/partition-table.bin
           version.txt
           tools/pyFlashGui/pyFlashGui.py
+
+    #### Platform-specific Emulator Builds
+    - name: Compile the Emulator
+      if: matrix.emulator && matrix.family == 'windows'
+      run: |
+        $env:path = $env:path.Insert($env:path.ToLower().IndexOf("c:\windows\system32"), "C:\msys64\mingw64\bin;C:\msys64\usr\bin;")
+        make -j2
+
+    - name: Compile the Emulator
+      if: matrix.emulator && matrix.family != 'windows'
+      run: |
+        make -j3
+
+    - name: Build OSX Bundle
+      if: matrix.emulator && matrix.family == 'osx'
+      run: |
+        make SwadgeEmulator.app
+
+    - name: Create Emulator zip
+      if: matrix.emulator
+      run: |
+        zip -r SwadgeEmulator.zip ${{ join(matrix.emu_artifacts) }}
+
+    #### Generic Emulator Upload
+    - name: Upload Emulator Binary
+      if: matrix.emulator
+      uses: actions/upload-artifact@v4.3.3
+      with:
+        name: SwadgeEmulator-${{ matrix.os }}
+        path: SwadgeEmulator.zip
 
   Create-Snapshot-Release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -75,21 +75,6 @@ jobs:
         printf "Commit: https://github.com/AEFeinstein/Super-2024-Swadge-FW/commit/$(git rev-parse HEAD) \nBuilt on ${{ matrix.os }} at: $(date)" >> version.txt
 
     #### Platform-specific Dependencies
-    - name: Install msys64 packages
-      if: matrix.family == 'windows'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: MINGW64
-        location: C:\msys64
-        install: >-
-          base-devel
-          gcc
-          gdb
-          zip
-          mingw-w64-x86_64-graphviz
-          mingw-w64-x86_64-cppcheck
-          doxygen
-
     - name: Install homebrew packages
       if: matrix.family == 'osx'
       run: |
@@ -153,6 +138,21 @@ jobs:
           tools/pyFlashGui/pyFlashGui.py
 
     #### Platform-specific Emulator Builds
+    - name: Install msys64 packages
+      if: matrix.emulator && matrix.family == 'windows'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        location: C:\msys64
+        install: >-
+          base-devel
+          gcc
+          gdb
+          zip
+          mingw-w64-x86_64-graphviz
+          mingw-w64-x86_64-cppcheck
+          doxygen
+
     - name: Compile the Emulator
       if: matrix.emulator && matrix.family == 'windows'
       run: |

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -174,7 +174,7 @@ jobs:
       if: matrix.emulator && matrix.family == 'windows'
       run: |
         cd C:\msys64
-        dir /s | findstr /i libwinpthread-1.dll
+        dir /A-D /S /B
         cp C:\msys64\bin\libwinpthread-1.dll libwinpthread-1.dll
 
     - name: Create Emulator zip

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -27,7 +27,6 @@ jobs:
             emu_artifacts:
               - swadge_emulator.exe
               - version.txt
-              - libwinpthread-1.dll
             # TODO: What variable can we use to not hardcode this???
             idf_install: C:\Users\runneradmin\.espressif
           - os: osx-arm
@@ -169,13 +168,6 @@ jobs:
       if: matrix.emulator && matrix.family == 'osx'
       run: |
         make SwadgeEmulator.app
-
-    - name: Copy libwinpthread DLL
-      if: matrix.emulator && matrix.family == 'windows'
-      run: |
-        cd C:\msys64
-        dir /A-D /S /B
-        cp C:\msys64\bin\libwinpthread-1.dll libwinpthread-1.dll
 
     - name: Create Emulator zip
       if: matrix.emulator && matrix.family != 'windows'

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -17,8 +17,19 @@ jobs:
   Build-Firmware-And-Emulator:
     strategy:
       matrix:
-        os: [ osx-arm, osx-intel, linux ]
+        os: [ windows, osx-arm, osx-intel, linux ]
         include:
+          - os: windows
+            runner: windows-latest
+            family: windows
+            emulator: true
+            firmware: true
+            emu_artifacts: |
+              swadge_emulator.exe
+              version.txt
+              C:\msys64\mingw64\bin\libwinpthread-1.dll
+            # TODO: What variable can we use to not hardcode this???
+            idf_install: C:\Users\runneradmin\.espressif
           - os: osx-arm
             runner: macos-latest
             family: osx

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -181,6 +181,10 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         merge-multiple: true
+    
+    - name: Testing
+      run: |
+        find .
 
     - name: Create release for latest artifacts
       if: (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -173,7 +173,8 @@ jobs:
     - name: Copy libwinpthread DLL
       if: matrix.emulator && matrix.family == 'windows'
       run: |
-        dir C:\msys64 /s | findstr /i libwinpthread-1.dll
+        cd C:\msys64
+        dir /s | findstr /i libwinpthread-1.dll
         cp C:\msys64\bin\libwinpthread-1.dll libwinpthread-1.dll
 
     - name: Create Emulator zip

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -185,6 +185,9 @@ jobs:
     permissions:
       contents: write
     steps:
+    - name: Download all previous build artifacts
+      uses: actions/download-artifact@v4
+
     - name: Create release for latest artifacts
       if: (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')
       uses: ncipollo/release-action@v1

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -184,7 +184,7 @@ jobs:
       if: matrix.emulator
       uses: actions/upload-artifact@v4.3.3
       with:
-        name: SwadgeEmulator-${{ matrix.os }}
+        name: ${{ env.EMULATOR_ARTIFACT }}-${{ matrix.os }}
         path: SwadgeEmulator.zip
 
   Create-Snapshot-Release:
@@ -204,11 +204,9 @@ jobs:
 
     - name: Rename artifacts
       run: |
-        mv ${{ env.EMULATOR_ARTIFACT }}-osx-arm/SwadgeEmulator.zip SwadgeEmulator-osx-arm.zip
-        mv ${{ env.EMULATOR_ARTIFACT }}-osx-intel/SwadgeEmulator.zip SwadgeEmulator-osx-intel.zip
-        mv ${{ env.EMULATOR_ARTIFACT }}-linux/swadge_emulator SwadgeEmulator-linux
-        #mv ${{ env.EMULATOR_ARTIFACT }}-windows/SwadgeEmulator.exe SwadgeEmulator-windows.exe
-        find .
+        for os in osx-arm osx-intel linux windows ; do
+        mv ${{ env.EMULATOR_ARTIFACT }}-${os}/SwadgeEmulator.zip SwadgeEmulator-${os}.zip
+        done
 
     - name: Create release for latest artifacts
       if: (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -185,7 +185,14 @@ jobs:
     - name: Testing
       run: |
         find .
-        unzip -l SwadgeEmulator.zip
+
+    - name: Rename artifacts
+      run: |
+        mv ${{ env.EMULATOR_ARTIFACT }}-osx-arm/SwadgeEmulator.zip SwadgeEmulator-osx-arm.zip
+        mv ${{ env.EMULATOR_ARTIFACT }}-osx-intel/SwadgeEmulator.zip SwadgeEmulator-osx-intel.zip
+        mv ${{ env.EMULATOR_ARTIFACT }}-linux/swadge_emulator SwadgeEmulator-linux
+        #mv ${{ env.EMULATOR_ARTIFACT }}-windows/SwadgeEmulator.exe SwadgeEmulator-windows.exe
+        find .
 
     - name: Create release for latest artifacts
       if: (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')
@@ -195,7 +202,7 @@ jobs:
         prerelease: true
         allowUpdates: true
         replacesArtifacts: true
-        artifacts: "${{ env.FIRMWARE_ARTIFACT }}/*,${{ env.EMULATOR_ARTIFACT }}-*/*"
+        artifacts: "${{ env.FIRMWARE_ARTIFACT }}/*,SwadgeEmulator-*"
         commit: main
         tag: snapshot
         name: Snapshot

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -230,7 +230,7 @@ jobs:
     needs: Build-Firmware-And-Emulator
     steps:
     - name: Post to a Slack channel
-      if: ((github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')) && false
+      if: (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')
       id: slack
       uses: slackapi/slack-github-action@v1.26.0
       with:

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -77,8 +77,18 @@ jobs:
     #### Platform-specific Dependencies
     - name: Install msys64 packages
       if: matrix.family == 'windows'
-      run: |
-        C:\msys64\usr\bin\bash -lc 'pacman --noconfirm -S base-devel gcc gdb zip mingw-w64-x86_64-graphviz mingw-w64-x86_64-cppcheck doxygen'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        location: C:\msys64
+        install: >-
+          base-devel
+          gcc
+          gdb
+          zip
+          mingw-w64-x86_64-graphviz
+          mingw-w64-x86_64-cppcheck
+          doxygen
 
     - name: Install homebrew packages
       if: matrix.family == 'osx'

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -173,6 +173,7 @@ jobs:
     - name: Copy libwinpthread DLL
       if: matrix.emulator && matrix.family == 'windows'
       run: |
+        dir C:\msys64 /s | findstr /i libwinpthread-1.dll
         cp C:\msys64\bin\libwinpthread-1.dll libwinpthread-1.dll
 
     - name: Create Emulator zip

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -181,10 +181,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         merge-multiple: true
-    
+
     - name: Testing
       run: |
         find .
+        unzip -l SwadgeEmulator.zip
 
     - name: Create release for latest artifacts
       if: (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -198,10 +198,6 @@ jobs:
       with:
         merge-multiple: false
 
-    - name: Testing
-      run: |
-        find .
-
     - name: Rename artifacts
       run: |
         for os in osx-arm osx-intel linux windows ; do

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -181,6 +181,7 @@ jobs:
 
   Create-Snapshot-Release:
     runs-on: ubuntu-latest
+    needs: Build-Firmware-And-Emulator
     permissions:
       contents: write
     steps:

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -17,16 +17,8 @@ jobs:
   Build-Firmware-And-Emulator:
     strategy:
       matrix:
-        os: [ windows, osx-arm, osx-intel, linux ]
+        os: [ osx-arm, osx-intel, linux ]
         include:
-          - os: windows
-            runner: windows-latest
-            family: windows
-            emulator: true
-            firmware: true
-            emu_binary: swadge_emulator.exe
-            # TODO: What variable can we use to not hardcode this???
-            idf_install: C:\Users\runneradmin\.espressif
           - os: osx-arm
             runner: macos-latest
             family: osx

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -170,10 +170,14 @@ jobs:
         make SwadgeEmulator.app
 
     - name: Create Emulator zip
-      if: matrix.emulator
+      if: matrix.emulator && matrix.family != 'windows'
       run: |
-        find .
         zip -r SwadgeEmulator.zip ${{ join(matrix.emu_artifacts, ' ') }}
+
+    - name: Create Emulator zip with 7zip
+      if: matrix.emulator && matrix.family == 'windows'
+      run: |
+        7z a -tzip SwadgeEmulator.zip ${{ join(matrix.emu_artifacts, ' ') }} -r
 
     #### Generic Emulator Upload
     - name: Upload Emulator Binary

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -194,11 +194,13 @@ jobs:
       contents: write
     steps:
     - name: Download all previous build artifacts
+      if: (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')
       uses: actions/download-artifact@v4
       with:
         merge-multiple: false
 
     - name: Rename artifacts
+      if: (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')
       run: |
         for os in osx-arm osx-intel linux windows ; do
         mv ${{ env.EMULATOR_ARTIFACT }}-${os}/SwadgeEmulator.zip SwadgeEmulator-${os}.zip

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -119,17 +119,6 @@ jobs:
         name: ${{ env.EMULATOR_ARTIFACT }}-${{ matrix.os }}
         pattern: ${{ env.EMULATOR_ARTIFACT }}-${{ matrix.os }}-*
         delete-merged: true
-    
-    - name: Add emulator artifact to release
-      if: matrix.emulator
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{ env.EMULATOR_ARTIFACT }}-${{ matrix.os}}-*
-        file_glob: true
-        prerelease: true
-        overwrite: true
-        tag: snapshot
 
     ## Firmware
     - name: Restore IDF Cache
@@ -181,16 +170,36 @@ jobs:
           build/partition_table/partition-table.bin
           version.txt
           tools/pyFlashGui/pyFlashGui.py
-    
-    - name: Add firmware artifact to release
-      if: matrix.firmware
-      uses: svenstaro/upload-release-action@v2
+
+  Create-Snapshot-Release:
+    runs-on: ubuntu-latest
+    needs: Build-Firmware-And-Emulator
+    permissions:
+      contents: write
+    steps:
+    - name: Download all previous build artifacts
+      uses: actions/download-artifact@v4
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{ env.FIRMWARE_ARTIFACT }}
+        merge-multiple: true
+    
+    - name: Testing
+      run: |
+        find .
+
+    - name: Create release for latest artifacts
+      if: (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')
+      uses: ncipollo/release-action@v1
+      with:
+        # Allow the release to be updated, since it's not a "final" release
         prerelease: true
-        overwrite: true
+        allowUpdates: true
+        replacesArtifacts: true
+        artifacts: "${{ env.FIRMWARE_ARTIFACT }}/*,${{ env.EMULATOR_ARTIFACT }}-*/*"
+        commit: main
         tag: snapshot
+        name: Snapshot
+        body: |
+          # Latest Development Snapshot
 
   Post-Slack-Message:
     runs-on: windows-latest

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -119,6 +119,17 @@ jobs:
         name: ${{ env.EMULATOR_ARTIFACT }}-${{ matrix.os }}
         pattern: ${{ env.EMULATOR_ARTIFACT }}-${{ matrix.os }}-*
         delete-merged: true
+    
+    - name: Add emulator artifact to release
+      if: matrix.emulator
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ${{ env.EMULATOR_ARTIFACT }}-${{ matrix.os}}-*
+        file_glob: true
+        prerelease: true
+        overwrite: true
+        tag: snapshot
 
     ## Firmware
     - name: Restore IDF Cache
@@ -170,36 +181,16 @@ jobs:
           build/partition_table/partition-table.bin
           version.txt
           tools/pyFlashGui/pyFlashGui.py
-
-  Create-Snapshot-Release:
-    runs-on: ubuntu-latest
-    needs: Build-Firmware-And-Emulator
-    permissions:
-      contents: write
-    steps:
-    - name: Download all previous build artifacts
-      uses: actions/download-artifact@v4
-      with:
-        merge-multiple: true
     
-    - name: Testing
-      run: |
-        find .
-
-    - name: Create release for latest artifacts
-      if: (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')
-      uses: ncipollo/release-action@v1
+    - name: Add firmware artifact to release
+      if: matrix.firmware
+      uses: svenstaro/upload-release-action@v2
       with:
-        # Allow the release to be updated, since it's not a "final" release
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ${{ env.FIRMWARE_ARTIFACT }}
         prerelease: true
-        allowUpdates: true
-        replacesArtifacts: true
-        artifacts: "${{ env.FIRMWARE_ARTIFACT }}/*,${{ env.EMULATOR_ARTIFACT }}-*/*"
-        commit: main
+        overwrite: true
         tag: snapshot
-        name: Snapshot
-        body: |
-          # Latest Development Snapshot
 
   Post-Slack-Message:
     runs-on: windows-latest

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -228,9 +228,7 @@ jobs:
     needs: Build-Firmware-And-Emulator
     steps:
     - name: Post to a Slack channel
-      env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      if: ((github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')) && ${{ env.SLACK_BOT_TOKEN != '' }}
+      if: ((github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')) && false
       id: slack
       uses: slackapi/slack-github-action@v1.26.0
       with:
@@ -240,3 +238,5 @@ jobs:
         channel-id: 'C6FNXU6KX'
         # For posting a simple plain text message
         slack-message: "*Build Result*: ${{ job.status }}\n*Author*: ${{ github.event.head_commit.author.username }}\n*Head Commit Message*:\n```\n${{ github.event.head_commit.message }}\n```\n*Comparison*: ${{ github.event.compare }}\n*Artifacts*: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -188,7 +188,7 @@ jobs:
         prerelease: true
         allowUpdates: true
         replacesArtifacts: true
-        artifacts: "${{ env.FIRMWARE_ARTIFACT }},${{ env.EMULATOR_ARTIFACT }}-*"
+        artifacts: "${{ env.FIRMWARE_ARTIFACT }}/*,${{ env.EMULATOR_ARTIFACT }}-*/*"
         commit: main
         tag: snapshot
         name: Snapshot

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -139,6 +139,7 @@ jobs:
 
     #### Platform-specific Emulator Builds
     - name: Install msys64 packages
+      id: install-msys64
       if: matrix.emulator && matrix.family == 'windows'
       uses: msys2/setup-msys2@v2
       with:
@@ -172,7 +173,8 @@ jobs:
     - name: Copy libwinpthread DLL
       if: matrix.emulator && matrix.family == 'windows'
       run: |
-        cp C:\msys64\mingw64\bin\libwinpthread-1.dll libwinpthread-1.dll
+        echo "${{ steps.install-msys64.outputs.msys2-location }}"
+        cp ${{ steps.install-msys64.outputs.msys2-location }}\bin\libwinpthread-1.dll libwinpthread-1.dll
 
     - name: Create Emulator zip
       if: matrix.emulator && matrix.family != 'windows'

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -180,7 +180,7 @@ jobs:
     - name: Download all previous build artifacts
       uses: actions/download-artifact@v4
       with:
-        merge-multiple: true
+        merge-multiple: false
 
     - name: Testing
       run: |

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -172,6 +172,7 @@ jobs:
     - name: Create Emulator zip
       if: matrix.emulator
       run: |
+        find .
         zip -r SwadgeEmulator.zip ${{ join(matrix.emu_artifacts) }}
 
     #### Generic Emulator Upload

--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -179,6 +179,8 @@ jobs:
     steps:
     - name: Download all previous build artifacts
       uses: actions/download-artifact@v4
+      with:
+        merge-multiple: true
 
     - name: Create release for latest artifacts
       if: (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref_name == 'main')

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["none"]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/docs/EMULATOR.md
+++ b/docs/EMULATOR.md
@@ -5,15 +5,14 @@ environment setup instructions, see [Configuring a Development Environment](#set
 
 ## Installing
 
-To install the emulator, go to the project's [releases page](https://github.com/AEFeinstein/Super-2024-Swadge-FW/releases)
-and download the appropriate `...-emulator.zip` for your operating system. Windows, Linux, and
+To install the emulator, go to the project's [releases page](https://github.com/AEFeinstein/Super-2024-Swadge-FW/releases/tags/snapshot)
+and download the appropriate `SwadgeEmulator-<os-type>.zip` for your operating system. Windows, Linux, and
 Mac (both Intel and ARM) are supported. Then, follow the instructions for your platform below.
 
 ### Windows
 
 The Windows version of the emulator does not require any other software to operate. Simply extract the
-`.zip` file anywhere you like and double-click on `swadge_emulator.exe`. Note that the
-`libwinpthread-1.dll` file included with the emulator download should be kept in the same folder.
+`.zip` file anywhere you like and double-click on `swadge_emulator.exe`.
 
 ### Linux
 

--- a/docs/EMULATOR.md
+++ b/docs/EMULATOR.md
@@ -233,6 +233,18 @@ If the emulator opens to the factory test mode instead of either the main menu o
 is because it is unable to write to the `nvs.json` file in the current directory.
 
 
+## Simulated ESPNOW Networking
+
+The Swadge Emulator is capable of simulating the wireless ESPNOW connection between two swadges. This
+functionality is enabled automatically by simply running two swadge emulator programs at the same time.
+For best results, you should start each Swadge Emulator from a different directory, to avoid potential
+corruption caused by two instances attempting to save data to the same `nvs.json` file at the same time.
+
+**Note**: This functionality only supports local connections between two Swadge Emulators running on the
+same machine. Networking between Swadge Emulators running on different machines is not supported at this
+time.
+
+
 ## MIDI Instructions
 
 The Swadge Emulator includes MIDI support, which simulates the USB-MIDI behavior of the real Swadge

--- a/docs/EMULATOR.md
+++ b/docs/EMULATOR.md
@@ -12,12 +12,17 @@ Mac (both Intel and ARM) are supported. Then, follow the instructions for your p
 ### Windows
 
 The Windows version of the emulator does not require any other software to operate. Simply extract the
-`.zip` file anywhere you like and double-click on `swadge_emulator.exe`.
+`.zip` file anywhere you like and double-click on `swadge_emulator.exe`. The first time you open the
+application, you may be warned about running applications from the internet and will need to click
+"Run" to continue. You might also be prompted by the Windows firewall when starting certain Swadge modes.
+This is only required if you wish to run two emulators at the same time using the simulated ESPNOW
+wireless connection.
 
 ### Linux
 
-After extracting the `.zip` file, you may need to mark the `swadge_emulator` binary as executable,
-which can be done with the command `chmod +x swadge_emulator`.
+The Linux version of the emulator does not require any other software to operate. Simply extract the
+`.zip` file anywhere you like and run the `swadge_emulator` program, either by opening it from your
+file browser or by running `./swadge_emulator` from the command-line.
 
 ### Mac
 

--- a/makefile
+++ b/makefile
@@ -247,7 +247,7 @@ OBJECTS = $(patsubst %.c, $(OBJ_DIR)/%.o, $(SOURCES))
 # This is a list of libraries to include. Order doesn't matter
 
 ifeq ($(HOST_OS),Windows)
-    LIBS = opengl32 gdi32 pthread user32 winmm WSock32
+    LIBS = opengl32 gdi32 user32 winmm WSock32
 endif
 ifeq ($(HOST_OS),Linux)
     LIBS = m X11 asound pulse rt GL GLX pthread Xext Xinerama
@@ -290,6 +290,10 @@ LIBRARY_FLAGS += \
 ifeq ($(ENABLE_GCOV),true)
     LIBRARY_FLAGS += -lgcov -fprofile-arcs -ftest-coverage
 endif
+endif
+
+ifeq ($(HOST_OS),Windows)
+	LIBRARY_FLAGS += -Wl,-Bstatic -lpthread
 endif
 
 ################################################################################

--- a/makefile
+++ b/makefile
@@ -247,7 +247,7 @@ OBJECTS = $(patsubst %.c, $(OBJ_DIR)/%.o, $(SOURCES))
 # This is a list of libraries to include. Order doesn't matter
 
 ifeq ($(HOST_OS),Windows)
-    LIBS = opengl32 gdi32 user32 winmm WSock32
+    LIBS = opengl32 gdi32 pthread user32 winmm WSock32
 endif
 ifeq ($(HOST_OS),Linux)
     LIBS = m X11 asound pulse rt GL GLX pthread Xext Xinerama


### PR DESCRIPTION
### Description

* The CI process was updated to automatically create a new github release called "snapshot" whenever changes are merged to main.
* The Windows build now uses static `pthread` instead of linking against the shared `libwinpthread-1`, so including `libwinpthread-1.dll` in the artifact is no longer necessary!
* Minor updates to documentation to reflect changes.
* Finally using msys2 action with caching for Windows (I ended up switching the order of the firmware / emulator as suggested). Now it's almost a whole minute faster!

### Test Instructions

Here's an example from my fork of what this will create: https://github.com/dylwhich/Swadge-IDF-5.0/releases/tag/snapshot.

Before merging, you can download the artifacts from the action (or from the last run on my fork) and check that all the files are there. You should be able to just unzip and double-click on any platform now!

Check the firmware to make sure everything is there.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
