### PR TITLE
Emulator MIDI File Opening

### DIFF
--- a/docs/EMULATOR.md
+++ b/docs/EMULATOR.md
@@ -81,6 +81,7 @@ Emulates a swadge
      --hide-leds             Don't draw simulated LEDs next to the display
  -k, --keymap=LAYOUT         Use an alternative keymap. LAYOUT can be azerty, colemak, or dvorak
  -l, --lock                  Lock the emulator in the start mode
+     --midi-file=FILE        Open and immediately play a MIDI file
  -m, --mode=MODE             Start the emulator in the swadge mode MODE instead of the main menu
      --mode-switch[=TIME]    Enable or set the timer to switch modes automatically
      --modes-list            Print out a list of all possible values for MODE
@@ -222,6 +223,8 @@ inputs to ensure that slight differences in frame timing do not cause inconsiste
 modes. The mode can still be changed automatically by `--mode-switch`, the console, and by a `SetMode'
 command when replaying recorded inputs.
 
+`--midi-file`: Loads and plays a local MIDI or KAR file using the MIDI Player mode.
+
 `--seed`: Sets a specific seed to the pseudorandom number generator. This is useful when trying to reproduce
 behavior that relies on `esp_random()`. If the seed is not set, a time-based one will be used. Note that a seed
 from one system will not necessarily produce the same output if it is used on a different system.
@@ -251,6 +254,10 @@ time.
 
 
 ## MIDI Instructions
+
+MIDI Files (`.mid`, `.midi`, and `.kar`) can be played in directly by passing the name of
+the MIDI file as a command-line argument to the Swadge Emulator. On Windows, you should also be able
+to drag a MIDI file on top of `SwadgeEmulator.exe` to play it.
 
 The Swadge Emulator includes MIDI support, which simulates the USB-MIDI behavior of the real Swadge
 using the system MIDI implementation. Note that MIDI implementation and behavior will vary between

--- a/emulator/src/components/hdw-nvs/hdw-nvs.c
+++ b/emulator/src/components/hdw-nvs/hdw-nvs.c
@@ -17,6 +17,7 @@
 #include "cJSON.h"
 #include "emu_main.h"
 #include "emu_utils.h"
+#include "hashMap.h"
 
 //==============================================================================
 // Defines
@@ -30,6 +31,21 @@
 #define NVS_OVERHEAD_ENTRIES 12
 
 //==============================================================================
+// Structs
+//==============================================================================
+
+typedef struct
+{
+    char key[36];
+    uint32_t size;
+    bool isBlob;
+    union {
+        void* blob;
+        int32_t int32;
+    };
+} emuNvsInjectedData_t;
+
+//==============================================================================
 // Function Prototypes
 //==============================================================================
 
@@ -37,6 +53,9 @@ static char* blobToStr(const void* value, size_t length);
 static int hexCharToInt(char c);
 static void strToBlob(char* str, void* outBlob, size_t blobLen);
 static FILE* openNvsFile(const char* mode);
+static size_t emuGetInjectedBlobLength(const char* namespace, const char* key);
+static void* emuGetInjectedBlob(const char* namespace, const char* key);
+static bool emuGetInjected32(const char* namespace, const char* key, int32_t* out);
 
 //==============================================================================
 // Constants
@@ -58,6 +77,8 @@ static const char* defaultNvsFiles[] = {
 // Variables
 //==============================================================================
 static const char** nvsFileName = defaultNvsFiles;
+static bool nvsInjectedDataInit = false;
+static hashMap_t nvsInjectedData;
 
 //==============================================================================
 // Functions
@@ -72,6 +93,12 @@ static const char** nvsFileName = defaultNvsFiles;
  */
 bool initNvs(bool firstTry)
 {
+    if (!nvsInjectedDataInit)
+    {
+        hashInit(&nvsInjectedData, 16);
+        nvsInjectedDataInit = true;
+    }
+
     const char** curFile;
     for (curFile = defaultNvsFiles; curFile < (defaultNvsFiles + (sizeof(defaultNvsFiles) / sizeof(*defaultNvsFiles)));
          curFile++)
@@ -146,6 +173,17 @@ bool initNvs(bool firstTry)
  */
 bool deinitNvs(void)
 {
+    if (nvsInjectedDataInit)
+    {
+        hashIterator_t iter = {0};
+        while (hashIterate(&nvsInjectedData, &iter))
+        {
+            free(iter.value);
+            hashIterRemove(&nvsInjectedData, &iter);
+        }
+        hashDeinit(&nvsInjectedData);
+        nvsInjectedDataInit = false;
+    }
     return true; // Nothing to do
 }
 
@@ -211,6 +249,11 @@ bool writeNvs32(const char* key, int32_t val)
  */
 bool readNamespaceNvs32(const char* namespace, const char* key, int32_t* outVal)
 {
+    if (emuGetInjected32(namespace, key, outVal))
+    {
+        return true;
+    }
+
     // Open the file
     FILE* nvsFile = openNvsFile("rb");
     if (NULL != nvsFile)
@@ -381,6 +424,21 @@ bool writeNamespaceNvs32(const char* namespace, const char* key, int32_t val)
  */
 bool readNamespaceNvsBlob(const char* namespace, const char* key, void* out_value, size_t* length)
 {
+    void* resultData = emuGetInjectedBlob(namespace, key);
+    if (resultData != NULL)
+    {
+        if (out_value != NULL)
+        {
+            memcpy(out_value, resultData, *length);
+        }
+        else
+        {
+            size_t injectedLength = emuGetInjectedBlobLength(namespace, key);
+            *length = injectedLength;
+        }
+        return true;
+    }
+
     // Open the file
     FILE* nvsFile = openNvsFile("rb");
     if (NULL != nvsFile)
@@ -1024,4 +1082,115 @@ static FILE* openNvsFile(const char* mode)
     expandPath(buffer, sizeof(buffer), NVS_JSON_FILE);
 
     return fopen(buffer, mode);
+}
+
+void emuInjectNvsBlob(const char* namespace, const char* key, size_t length, const void* blob)
+{
+    if (!nvsInjectedDataInit)
+    {
+        hashInit(&nvsInjectedData, 16);
+        nvsInjectedDataInit = true;
+    }
+
+    void* alloc = malloc(sizeof(emuNvsInjectedData_t) + length);
+    if (alloc != NULL)
+    {
+        emuNvsInjectedData_t* data = (emuNvsInjectedData_t*)alloc;
+
+        snprintf(data->key, sizeof(data->key), "%s:%s", namespace, key);
+        data->size = (uint32_t)length;
+        data->isBlob = true;
+        data->blob = ((char*)alloc) + sizeof(emuNvsInjectedData_t);
+        memcpy(data->blob, blob, length);
+
+        hashPut(&nvsInjectedData, data->key, alloc);
+    }
+}
+
+void emuInjectNvs32(const char* namespace, const char* key, int32_t value)
+{
+    if (!nvsInjectedDataInit)
+    {
+        hashInit(&nvsInjectedData, 16);
+        nvsInjectedDataInit = true;
+    }
+
+    void* alloc = malloc(sizeof(emuNvsInjectedData_t));
+    if (alloc != NULL)
+    {
+        emuNvsInjectedData_t* data = (emuNvsInjectedData_t*)alloc;
+
+        snprintf(data->key, sizeof(data->key), "%s:%s", namespace, key);
+        data->size = 4;
+        data->isBlob = false;
+        data->int32 = value;
+
+        hashPut(&nvsInjectedData, data->key, alloc);
+    }
+}
+
+static size_t emuGetInjectedBlobLength(const char* namespace, const char* key)
+{
+    if (!nvsInjectedDataInit)
+    {
+        return 0;
+    }
+
+    char fullkey[36];
+    snprintf(fullkey, sizeof(fullkey), "%s:%s", namespace, key);
+    void* found = hashGet(&nvsInjectedData, fullkey);
+
+    if (found != NULL)
+    {
+        return ((emuNvsInjectedData_t*)found)->size;
+    }
+
+    return 0;
+}
+
+static void* emuGetInjectedBlob(const char* namespace, const char* key)
+{
+    if (!nvsInjectedDataInit)
+    {
+        return NULL;
+    }
+
+    char fullkey[36];
+    snprintf(fullkey, sizeof(fullkey), "%s:%s", namespace, key);
+    void* found = hashGet(&nvsInjectedData, fullkey);
+
+    if (found != NULL)
+    {
+        emuNvsInjectedData_t* data = (emuNvsInjectedData_t*)found;
+        if (data->isBlob)
+        {
+            return data->blob;
+        }
+    }
+
+    return NULL;
+}
+
+static bool emuGetInjected32(const char* namespace, const char* key, int32_t* out)
+{
+    if (!nvsInjectedDataInit)
+    {
+        return false;
+    }
+
+    char fullkey[36];
+    snprintf(fullkey, sizeof(fullkey), "%s:%s", namespace, key);
+    void* found = hashGet(&nvsInjectedData, fullkey);
+
+    if (found != NULL)
+    {
+        emuNvsInjectedData_t* data = (emuNvsInjectedData_t*)found;
+        if (!data->isBlob)
+        {
+            *out = data->int32;
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/emulator/src/components/hdw-nvs/hdw-nvs.c
+++ b/emulator/src/components/hdw-nvs/hdw-nvs.c
@@ -39,7 +39,8 @@ typedef struct
     char key[36];
     uint32_t size;
     bool isBlob;
-    union {
+    union
+    {
         void* blob;
         int32_t int32;
     };
@@ -434,7 +435,7 @@ bool readNamespaceNvsBlob(const char* namespace, const char* key, void* out_valu
         else
         {
             size_t injectedLength = emuGetInjectedBlobLength(namespace, key);
-            *length = injectedLength;
+            *length               = injectedLength;
         }
         return true;
     }
@@ -1098,9 +1099,9 @@ void emuInjectNvsBlob(const char* namespace, const char* key, size_t length, con
         emuNvsInjectedData_t* data = (emuNvsInjectedData_t*)alloc;
 
         snprintf(data->key, sizeof(data->key), "%s:%s", namespace, key);
-        data->size = (uint32_t)length;
+        data->size   = (uint32_t)length;
         data->isBlob = true;
-        data->blob = ((char*)alloc) + sizeof(emuNvsInjectedData_t);
+        data->blob   = ((char*)alloc) + sizeof(emuNvsInjectedData_t);
         memcpy(data->blob, blob, length);
 
         hashPut(&nvsInjectedData, data->key, alloc);
@@ -1121,9 +1122,9 @@ void emuInjectNvs32(const char* namespace, const char* key, int32_t value)
         emuNvsInjectedData_t* data = (emuNvsInjectedData_t*)alloc;
 
         snprintf(data->key, sizeof(data->key), "%s:%s", namespace, key);
-        data->size = 4;
+        data->size   = 4;
         data->isBlob = false;
-        data->int32 = value;
+        data->int32  = value;
 
         hashPut(&nvsInjectedData, data->key, alloc);
     }

--- a/emulator/src/components/hdw-nvs/hdw-nvs_emu.h
+++ b/emulator/src/components/hdw-nvs/hdw-nvs_emu.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+void emuInjectNvsBlob(const char* namespace, const char* key, size_t length, const void* blob);
+void emuInjectNvs32(const char* namespace, const char* key, int32_t value);

--- a/emulator/src/emu_cnfs.c
+++ b/emulator/src/emu_cnfs.c
@@ -1,0 +1,102 @@
+#include "emu_cnfs.h"
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <malloc.h>
+
+#include "esp_heap_caps.h"
+
+static char* cnfsInjectedFilename = NULL;
+static int32_t cnfsInjectedFileSize = 0;
+static void* cnfsInjectedFileData = NULL;
+
+const uint8_t* __real_cnfsGetFile(const char* fname, size_t* flen);
+
+bool emuCnfsInjectFile(const char* name, const char* filePath)
+{
+    FILE* dataFile = fopen(filePath, "rb");
+    if (dataFile != NULL)
+    {
+        fseek(dataFile, 0L, SEEK_END);
+        size_t fileSize = ftell(dataFile);
+        fseek(dataFile, 0L, SEEK_SET);
+
+        if (fileSize > 0)
+        {
+            void* fileData = malloc(fileSize);
+            if (fileData != NULL)
+            {
+                if (fileSize == fread(fileData, 1, fileSize, dataFile))
+                {
+                    fclose(dataFile);
+                    emuCnfsInjectFileData(name, fileSize, fileData);
+                    return true;
+                }
+            }
+        }
+        
+        fclose(dataFile);
+        return false;
+    }
+    else
+    {
+        printf("ERR: Could not open %s\n", filePath);
+        return false;
+    }
+}
+
+void emuCnfsInjectFileData(const char* name, size_t length, void* data)
+{
+    cnfsInjectedFilename = strdup(name);
+    cnfsInjectedFileSize = length;
+    cnfsInjectedFileData = data;
+}
+
+/*bool __wrap_deinitCnfs(void)
+{
+    free(cnfsInjectedFilename);
+    free(cnfsInjectedFileData);
+
+    cnfsInjectedFileSize = 0;
+    cnfsInjectedFilename = NULL;
+    cnfsInjectedFileData = NULL;
+}*/
+
+const uint8_t* __wrap_cnfsGetFile(const char* fname, size_t* flen)
+{
+    if (cnfsInjectedFilename && !strcmp(cnfsInjectedFilename, fname))
+    {
+        *flen = cnfsInjectedFileSize;
+        return (uint8_t*)cnfsInjectedFileData;
+    }
+    else
+    {
+        return __real_cnfsGetFile(fname, flen);
+    }
+}
+
+// Hack needed because we can't actually wrap the call that cnfsReadFile() makes to cnfsGetFile() because of compiler shenanigans
+uint8_t* __wrap_cnfsReadFile(const char* fname, size_t* outsize, bool readToSpiRam)
+{
+    const uint8_t* fptr = __wrap_cnfsGetFile(fname, outsize);
+
+    if (!fptr)
+    {
+        return 0;
+    }
+
+    uint8_t* output;
+
+    if (readToSpiRam)
+    {
+        output = (uint8_t*)heap_caps_calloc((*outsize + 1), sizeof(uint8_t), MALLOC_CAP_SPIRAM);
+    }
+    else
+    {
+        output = (uint8_t*)calloc((*outsize + 1), sizeof(uint8_t));
+    }
+    memcpy(output, fptr, *outsize);
+    return output;
+}

--- a/emulator/src/emu_cnfs.c
+++ b/emulator/src/emu_cnfs.c
@@ -8,9 +8,9 @@
 
 #include "esp_heap_caps.h"
 
-static char* cnfsInjectedFilename = NULL;
+static char* cnfsInjectedFilename   = NULL;
 static int32_t cnfsInjectedFileSize = 0;
-static void* cnfsInjectedFileData = NULL;
+static void* cnfsInjectedFileData   = NULL;
 
 const uint8_t* __real_cnfsGetFile(const char* fname, size_t* flen);
 
@@ -36,7 +36,7 @@ bool emuCnfsInjectFile(const char* name, const char* filePath)
                 }
             }
         }
-        
+
         fclose(dataFile);
         return false;
     }
@@ -77,7 +77,8 @@ const uint8_t* __wrap_cnfsGetFile(const char* fname, size_t* flen)
     }
 }
 
-// Hack needed because we can't actually wrap the call that cnfsReadFile() makes to cnfsGetFile() because of compiler shenanigans
+// Hack needed because we can't actually wrap the call that cnfsReadFile() makes to cnfsGetFile() because of compiler
+// shenanigans
 uint8_t* __wrap_cnfsReadFile(const char* fname, size_t* outsize, bool readToSpiRam)
 {
     const uint8_t* fptr = __wrap_cnfsGetFile(fname, outsize);

--- a/emulator/src/emu_cnfs.c
+++ b/emulator/src/emu_cnfs.c
@@ -32,7 +32,7 @@ static void* cnfsInjectedFileData   = NULL;
 // Functions
 //==============================================================================
 
-bool __wrap_initCnfs(void)
+bool initCnfs(void)
 {
     /* Get local references from cnfs_data.c */
     cnfsData     = getCnfsImage();
@@ -85,7 +85,7 @@ void emuCnfsInjectFileData(const char* name, size_t length, void* data)
     cnfsInjectedFileData = data;
 }
 
-bool __wrap_deinitCnfs(void)
+bool deinitCnfs(void)
 {
     free(cnfsInjectedFilename);
     free(cnfsInjectedFileData);
@@ -97,7 +97,7 @@ bool __wrap_deinitCnfs(void)
     return true;
 }
 
-const uint8_t* __wrap_cnfsGetFile(const char* fname, size_t* flen)
+const uint8_t* cnfsGetFile(const char* fname, size_t* flen)
 {
     if (cnfsInjectedFilename && !strcmp(cnfsInjectedFilename, fname))
     {
@@ -138,9 +138,9 @@ const uint8_t* __wrap_cnfsGetFile(const char* fname, size_t* flen)
 
 // Hack needed because we can't actually wrap the call that cnfsReadFile() makes to cnfsGetFile() because of compiler
 // shenanigans
-uint8_t* __wrap_cnfsReadFile(const char* fname, size_t* outsize, bool readToSpiRam)
+uint8_t* cnfsReadFile(const char* fname, size_t* outsize, bool readToSpiRam)
 {
-    const uint8_t* fptr = __wrap_cnfsGetFile(fname, outsize);
+    const uint8_t* fptr = cnfsGetFile(fname, outsize);
 
     if (!fptr)
     {

--- a/emulator/src/emu_cnfs.c
+++ b/emulator/src/emu_cnfs.c
@@ -3,8 +3,8 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 
 #include "esp_heap_caps.h"
 

--- a/emulator/src/emu_cnfs.c
+++ b/emulator/src/emu_cnfs.c
@@ -13,6 +13,7 @@ static int32_t cnfsInjectedFileSize = 0;
 static void* cnfsInjectedFileData   = NULL;
 
 const uint8_t* __real_cnfsGetFile(const char* fname, size_t* flen);
+bool __real_deinitCnfs(void);
 
 bool emuCnfsInjectFile(const char* name, const char* filePath)
 {
@@ -54,7 +55,7 @@ void emuCnfsInjectFileData(const char* name, size_t length, void* data)
     cnfsInjectedFileData = data;
 }
 
-/*bool __wrap_deinitCnfs(void)
+bool __wrap_deinitCnfs(void)
 {
     free(cnfsInjectedFilename);
     free(cnfsInjectedFileData);
@@ -62,7 +63,9 @@ void emuCnfsInjectFileData(const char* name, size_t length, void* data)
     cnfsInjectedFileSize = 0;
     cnfsInjectedFilename = NULL;
     cnfsInjectedFileData = NULL;
-}*/
+
+    return __real_deinitCnfs();
+}
 
 const uint8_t* __wrap_cnfsGetFile(const char* fname, size_t* flen)
 {

--- a/emulator/src/emu_cnfs.h
+++ b/emulator/src/emu_cnfs.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+bool emuCnfsInjectFile(const char* name, const char* filePath);
+void emuCnfsInjectFileData(const char* name, size_t length, void* data);

--- a/emulator/src/emu_main.c
+++ b/emulator/src/emu_main.c
@@ -38,11 +38,6 @@
 #include "hdw-dac.h"
 #include "hdw-dac_emu.h"
 
-#include "hdw-nvs.h"
-#include "hdw-nvs_emu.h"
-
-#include "emu_cnfs.h"
-
 #include "swadge2024.h"
 #include "macros.h"
 #include "trigonometry.h"
@@ -95,7 +90,6 @@
 #include "emu_ext.h"
 #include "emu_main.h"
 #include "ext_tools.h"
-#include "ext_modes.h"
 
 //==============================================================================
 // Defines
@@ -190,23 +184,6 @@ int main(int argc, char** argv)
     // Call any init callbacks we may have and pass them the parsed command-line arguments
     // We also determine which extensions are enabled here, which is important for laying out the window properly
     initExtensions(&emulatorArgs);
-
-    // TODO this should also be an extension?
-    if (emulatorArgs.midiFile)
-    {
-        printf("Opening MIDI file: %s\n", emulatorArgs.midiFile);
-        if (emuCnfsInjectFile(emulatorArgs.midiFile, emulatorArgs.midiFile))
-        {
-            emuInjectNvs32("storage", "synth_playmode", 1);
-            emuInjectNvsBlob("storage", "synth_lastsong", strlen(emulatorArgs.midiFile), emulatorArgs.midiFile);
-            emulatorSetSwadgeModeByName("MIDI");
-        }
-        else
-        {
-            printf("Could not read MIDI file!\n");
-            isRunning = false;
-        }
-    }
 
     if (!isRunning)
     {

--- a/emulator/src/emu_main.c
+++ b/emulator/src/emu_main.c
@@ -38,6 +38,11 @@
 #include "hdw-dac.h"
 #include "hdw-dac_emu.h"
 
+#include "hdw-nvs.h"
+#include "hdw-nvs_emu.h"
+
+#include "emu_cnfs.h"
+
 #include "swadge2024.h"
 #include "macros.h"
 #include "trigonometry.h"
@@ -90,6 +95,7 @@
 #include "emu_ext.h"
 #include "emu_main.h"
 #include "ext_tools.h"
+#include "ext_modes.h"
 
 //==============================================================================
 // Defines
@@ -184,6 +190,23 @@ int main(int argc, char** argv)
     // Call any init callbacks we may have and pass them the parsed command-line arguments
     // We also determine which extensions are enabled here, which is important for laying out the window properly
     initExtensions(&emulatorArgs);
+
+    // TODO this should also be an extension?
+    if (emulatorArgs.midiFile)
+    {
+        printf("Opening MIDI file: %s\n", emulatorArgs.midiFile);
+        if (emuCnfsInjectFile(emulatorArgs.midiFile, emulatorArgs.midiFile))
+        {
+            emuInjectNvs32("storage", "synth_playmode", 1);
+            emuInjectNvsBlob("storage", "synth_lastsong", strlen(emulatorArgs.midiFile), emulatorArgs.midiFile);
+            emulatorSetSwadgeModeByName("MIDI");
+        }
+        else
+        {
+            printf("Could not read MIDI file!\n");
+            isRunning = false;
+        }
+    }
 
     if (!isRunning)
     {

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -68,6 +68,7 @@ typedef struct
 //==============================================================================
 
 static bool handleArgument(const char* optName, const char* arg, int optVal);
+static bool handlePositionalArgument(const char* val);
 static void printHelp(const char* progName);
 static void printUsage(const char* progName);
 static const optDoc_t* findOptDoc(char shortOpt, const char* longOpt);
@@ -414,6 +415,11 @@ static bool handleArgument(const char* optName, const char* arg, int optVal)
 
     // It's OK if an arg is unhandled, as it may just be a flag set automatically
     return true;
+}
+
+static bool handlePositionalArgument(const char* val)
+{
+    return false;
 }
 
 /**
@@ -841,8 +847,21 @@ bool emuParseArgs(int argc, char** argv)
 
         if (optVal < 0)
         {
-            // No more options
-            break;
+            // Not an option
+            if (optind < argc)
+            {
+                // ...but there are still arguments, so this is a positional arg
+                if (!handlePositionalArgument(argv[optind]))
+                {
+                    printf("Unknown argument '%s'\n", argv[optind]);
+                    return false;
+                }
+            }
+            else
+            {
+                // No more options
+                break;
+            }
         }
         else if (optVal == '?')
         {

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -419,6 +419,16 @@ static bool handleArgument(const char* optName, const char* arg, int optVal)
 
 static bool handlePositionalArgument(const char* val)
 {
+    if (val)
+    {
+        if ((strlen(val) > 4 && (!strcmp(&val[strlen(val) - 4], ".mid") || !strcmp(&val[strlen(val) - 4], ".kar")))
+            || (strlen(val) > 5 && !strcmp(&val[strlen(val) - 5], ".midi")))
+        {
+            emulatorArgs.midiFile = val;
+            return true;
+        }
+    }
+
     return false;
 }
 

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -137,6 +137,7 @@ static const char argHeadless[]    = "headless";
 static const char argHideLeds[]    = "hide-leds";
 static const char argKeymap[]      = "keymap";
 static const char argLock[]        = "lock";
+static const char argMidiFile[]    = "midi-file";
 static const char argMode[]        = "mode";
 static const char argModeSwitch[]  = "mode-switch";
 static const char argModeList[]    = "modes-list";
@@ -167,6 +168,7 @@ static const struct option options[] =
     { argHideLeds,    no_argument,       (int*)&emulatorArgs.hideLeds,     true },
     { argKeymap,      required_argument, NULL,                             'k'  },
     { argLock,        no_argument,       (int*)&emulatorArgs.lock,         true },
+    { argMidiFile,    required_argument, NULL,                             0    },
     { argMode,        required_argument, NULL,                             'm'  },
     { argPlayback,    required_argument, (int*)&emulatorArgs.playback,     'p'  },
     { argRecord,      optional_argument, (int*)&emulatorArgs.record,       'r'  },
@@ -198,6 +200,7 @@ static const optDoc_t argDocs[] =
     { 0,  argHideLeds,    NULL,    "Don't draw simulated LEDs next to the display" },
     {'k', argKeymap,     "LAYOUT", "Use an alternative keymap. LAYOUT can be azerty, colemak, or dvorak"},
     {'l', argLock,        NULL,    "Lock the emulator in the start mode" },
+    { 0,  argMidiFile,    "FILE",  "Open and immediately play a MIDI file" },
     {'m', argMode,        "MODE",  "Start the emulator in the swadge mode MODE instead of the main menu"},
     { 0,  argModeSwitch,  "TIME",  "Enable or set the timer to switch modes automatically" },
     { 0,  argModeList,    NULL,    "Print out a list of all possible values for MODE" },
@@ -312,6 +315,10 @@ static bool handleArgument(const char* optName, const char* arg, int optVal)
             emulatorArgs.keymap = arg;
         }
         return true;
+    }
+    else if (argMidiFile == optName)
+    {
+        emulatorArgs.midiFile = arg;
     }
     else if (argMode == optName)
     {

--- a/emulator/src/extensions/emu_args.h
+++ b/emulator/src/extensions/emu_args.h
@@ -75,7 +75,6 @@ typedef struct
     /// @brief Whether VSync is enabled
     bool vsync;
 
-
     // MIDI
     const char* midiFile;
 } emuArgs_t;

--- a/emulator/src/extensions/emu_args.h
+++ b/emulator/src/extensions/emu_args.h
@@ -74,6 +74,10 @@ typedef struct
 
     /// @brief Whether VSync is enabled
     bool vsync;
+
+
+    // MIDI
+    const char* midiFile;
 } emuArgs_t;
 
 //==============================================================================

--- a/emulator/src/extensions/emu_ext.c
+++ b/emulator/src/extensions/emu_ext.c
@@ -17,6 +17,7 @@
 #include "ext_leds.h"
 #include "ext_fuzzer.h"
 #include "ext_keymap.h"
+#include "ext_midi.h"
 #include "ext_modes.h"
 #include "ext_replay.h"
 #include "ext_tools.h"
@@ -31,7 +32,7 @@
 
 static const emuExtension_t* registeredExtensions[] = {
     &touchEmuCallback,  &ledEmuExtension,   &fuzzerEmuExtension, &toolsEmuExtension,
-    &keymapEmuCallback, &modesEmuExtension, &replayEmuExtension,
+    &keymapEmuCallback, &modesEmuExtension, &replayEmuExtension, &midiEmuExtension,
 };
 
 //==============================================================================

--- a/emulator/src/extensions/midi/ext_midi.c
+++ b/emulator/src/extensions/midi/ext_midi.c
@@ -1,0 +1,59 @@
+#include "ext_midi.h"
+#include "emu_ext.h"
+#include "emu_main.h"
+
+#include "hdw-nvs_emu.h"
+#include "emu_cnfs.h"
+#include "ext_modes.h"
+#include "mode_synth.h"
+
+#include <stdbool.h>
+
+//==============================================================================
+// Function Prototypes
+//==============================================================================
+
+static bool midiInitCb(emuArgs_t* emuArgs);
+
+//==============================================================================
+// Variables
+//==============================================================================
+
+emuExtension_t midiEmuExtension = {
+    .name            = "midi",
+    .fnInitCb        = midiInitCb,
+    .fnPreFrameCb    = NULL,
+    .fnPostFrameCb   = NULL,
+    .fnKeyCb         = NULL,
+    .fnMouseMoveCb   = NULL,
+    .fnMouseButtonCb = NULL,
+    .fnRenderCb      = NULL,
+};
+
+//==============================================================================
+// Functions
+//==============================================================================
+
+static bool midiInitCb(emuArgs_t* emuArgs)
+{
+    if (emuArgs->midiFile)
+    {
+        printf("Opening MIDI file: %s\n", emuArgs->midiFile);
+        if (emuCnfsInjectFile(emuArgs->midiFile, emuArgs->midiFile))
+        {
+            emuInjectNvs32("storage", "synth_playmode", 1);
+            emuInjectNvsBlob("storage", "synth_lastsong", strlen(emuArgs->midiFile), emuArgs->midiFile);
+            emulatorSetSwadgeModeByName(synthMode.modeName);
+        }
+        else
+        {
+            printf("Could not read MIDI file!\n");
+            emulatorQuit();
+            return false;
+        }
+
+        return true;
+    }
+
+    return false;
+}

--- a/emulator/src/extensions/midi/ext_midi.h
+++ b/emulator/src/extensions/midi/ext_midi.h
@@ -1,0 +1,10 @@
+/*! \file ext_midi.h
+ *
+ * \section ext_midi Extended Emulator MIDI Support
+ */
+
+#pragma once
+
+#include "emu_ext.h"
+
+extern emuExtension_t midiEmuExtension;

--- a/makefile
+++ b/makefile
@@ -269,20 +269,23 @@ endif
 
 # This combines the flags for the linker to find and use libraries
 LIBRARY_FLAGS = $(patsubst %, -L%, $(LIB_DIRS)) $(patsubst %, -l%, $(LIBS)) \
-	-ggdb \
-	-Wl,--wrap=cnfsGetFile,--wrap=cnfsReadFile,--wrap=deinitCnfs
+	-ggdb
 
 # Incompatible flags for clang on MacOS
 ifneq ($(HOST_OS),Darwin)
 LIBRARY_FLAGS += \
 	-static-libgcc \
-	-static-libstdc++
+	-static-libstdc++ \
+	-Wl,--wrap=cnfsGetFile,--wrap=cnfsReadFile,--wrap=deinitCnfs
 else
 LIBRARY_FLAGS += \
     -framework Foundation \
 	-framework CoreFoundation \
 	-framework CoreMIDI \
-	-framework AudioToolbox
+	-framework AudioToolbox \
+	-Wl,-alias,__wrap_cnfsGetFile,cnfsGetFile \
+	-Wl,-alias,__wrap_cnfsReadFile,cnfsReadFile \
+	-Wl,-alias,__wrap_deinitCnfs,deinitCnfs
 endif
 
 ifeq ($(HOST_OS),Linux)

--- a/makefile
+++ b/makefile
@@ -271,7 +271,8 @@ endif
 LIBRARY_FLAGS = $(patsubst %, -L%, $(LIB_DIRS)) $(patsubst %, -l%, $(LIBS)) \
 	-ggdb \
 	-Wl,--wrap=cnfsGetFile \
-	-Wl,--wrap=cnfsReadFile
+	-Wl,--wrap=cnfsReadFile \
+	-Wl,--wrap=deinitCnfs
 
 # Incompatible flags for clang on MacOS
 ifneq ($(HOST_OS),Darwin)

--- a/makefile
+++ b/makefile
@@ -276,7 +276,7 @@ ifneq ($(HOST_OS),Darwin)
 LIBRARY_FLAGS += \
 	-static-libgcc \
 	-static-libstdc++ \
-	-Wl,--wrap=cnfsGetFile,--wrap=cnfsReadFile,--wrap=deinitCnfs
+	-Wl,--wrap=cnfsGetFile,--wrap=cnfsReadFile,--wrap=initCnfs,--wrap=deinitCnfs
 else
 LIBRARY_FLAGS += \
     -framework Foundation \
@@ -285,6 +285,7 @@ LIBRARY_FLAGS += \
 	-framework AudioToolbox \
 	-Wl,-alias,__wrap_cnfsGetFile,cnfsGetFile \
 	-Wl,-alias,__wrap_cnfsReadFile,cnfsReadFile \
+	-Wl,-alias,__wrap_initCnfs,initCnfs \
 	-Wl,-alias,__wrap_deinitCnfs,deinitCnfs
 endif
 

--- a/makefile
+++ b/makefile
@@ -270,9 +270,7 @@ endif
 # This combines the flags for the linker to find and use libraries
 LIBRARY_FLAGS = $(patsubst %, -L%, $(LIB_DIRS)) $(patsubst %, -l%, $(LIBS)) \
 	-ggdb \
-	-Wl,--wrap=cnfsGetFile \
-	-Wl,--wrap=cnfsReadFile \
-	-Wl,--wrap=deinitCnfs
+	-Wl,--wrap=cnfsGetFile,--wrap=cnfsReadFile,--wrap=deinitCnfs
 
 # Incompatible flags for clang on MacOS
 ifneq ($(HOST_OS),Darwin)

--- a/makefile
+++ b/makefile
@@ -283,10 +283,10 @@ LIBRARY_FLAGS += \
 	-framework CoreFoundation \
 	-framework CoreMIDI \
 	-framework AudioToolbox \
-	-Wl,-alias,__wrap_cnfsGetFile,cnfsGetFile \
-	-Wl,-alias,__wrap_cnfsReadFile,cnfsReadFile \
-	-Wl,-alias,__wrap_initCnfs,initCnfs \
-	-Wl,-alias,__wrap_deinitCnfs,deinitCnfs
+	-Wl,-alias,cnfsGetFile,__wrap_cnfsGetFile \
+	-Wl,-alias,cnfsReadFile,__wrap_cnfsReadFile \
+	-Wl,-alias,initCnfs,__wrap_initCnfs \
+	-Wl,-alias,deinitCnfs,__wrap_deinitCnfs
 endif
 
 ifeq ($(HOST_OS),Linux)

--- a/makefile
+++ b/makefile
@@ -269,7 +269,9 @@ endif
 
 # This combines the flags for the linker to find and use libraries
 LIBRARY_FLAGS = $(patsubst %, -L%, $(LIB_DIRS)) $(patsubst %, -l%, $(LIBS)) \
-	-ggdb
+	-ggdb \
+	-Wl,--wrap=cnfsGetFile \
+	-Wl,--wrap=cnfsReadFile
 
 # Incompatible flags for clang on MacOS
 ifneq ($(HOST_OS),Darwin)

--- a/makefile
+++ b/makefile
@@ -66,6 +66,7 @@ SRC_FILES = $(CNFS_FILE)
 SRC_DIRS = $(shell $(FIND) $(SRC_DIRS_RECURSIVE) -type d) $(SRC_DIRS_FLAT)
 # This is all the source files combined and deduplicated
 SOURCES   = $(sort $(shell $(FIND) $(SRC_DIRS) -maxdepth 1 -iname "*.[c]") $(SRC_FILES))
+SOURCES   := $(filter-out main/utils/cnfs.c, $(SOURCES))
 
 # The emulator doesn't build components, but there is a target for formatting them
 ALL_FILES = $(shell $(FIND) components $(SRC_DIRS_RECURSIVE) -iname "*.[c|h]")
@@ -275,18 +276,13 @@ LIBRARY_FLAGS = $(patsubst %, -L%, $(LIB_DIRS)) $(patsubst %, -l%, $(LIBS)) \
 ifneq ($(HOST_OS),Darwin)
 LIBRARY_FLAGS += \
 	-static-libgcc \
-	-static-libstdc++ \
-	-Wl,--wrap=cnfsGetFile,--wrap=cnfsReadFile,--wrap=initCnfs,--wrap=deinitCnfs
+	-static-libstdc++
 else
 LIBRARY_FLAGS += \
     -framework Foundation \
 	-framework CoreFoundation \
 	-framework CoreMIDI \
-	-framework AudioToolbox \
-	-Wl,-alias,cnfsGetFile,__wrap_cnfsGetFile \
-	-Wl,-alias,cnfsReadFile,__wrap_cnfsReadFile \
-	-Wl,-alias,initCnfs,__wrap_initCnfs \
-	-Wl,-alias,deinitCnfs,__wrap_deinitCnfs
+	-framework AudioToolbox
 endif
 
 ifeq ($(HOST_OS),Linux)


### PR DESCRIPTION
### Description

Adds the ability to open a MIDI file with `--midi-file <filename>`, which starts the emulator in the `MIDI Player` mode and does some magic to inject the MIDI File contents into a fake CNFS entry. You can also omit the `--midi-file` argument and pass the MIDI file as the last argument, which should make dragging a MIDI file onto the executable Just Work to open things on Windows at least.

### Test Instructions

- Use `--midi-file` to start the emulator with a specific MIDI file
- Try to open a nonexistent file with `--midi-file` and check that the error message makes sense
- Try dragging a MIDI file onto the executable (on Windows)

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
