### PR TITLE
MIDI Registered/Non-registered Parameter Support, default instrument changes

### DIFF
--- a/docs/MIDI.md
+++ b/docs/MIDI.md
@@ -74,3 +74,18 @@ fine and coarse adjustment knobs on a real audio device, but some editing softwa
 | 73       | Attack Time     | 0-127                   | Set the length of time (in 10ms increments) it will take for a note to reach its maximum volume after it starts playing. | |
 | 75       | Decay Time      | 0-127                   | Set the length of time (in 10ms increments) it will take for a note to fade from its maximum volume to its sustain volume. | |
 | 76       | Sustain Level   | 0-127                   | Set the volume level the note will reach at the end of the decay time, and will be maintained as long as the note is held on. | |
+| 6, 38    | Data Entry      | 0-16383                 | Set the value of the registered or non-registered parameter that was selected previously using the `Registered Parameter` or `Non-registered Parameter` controllers. | |
+| 96       | Data Button Increment | 0 (not used)      | Increments the value of the registered or non-registered parameter by one | |
+| 97       | Data Button Decrement | 0 (not used)      | Decrements the value of the registered or non-registered parameter by one | |
+| 98, 99   | Non-registered Parameter | 0-16383        | Selects a non-registered parameter to be changed with the `Data Entry`or `Data Button` controllers. | |
+| 101, 100 | Registered Parameter | 0-16383            | Selects a registered parameter value to be changed with the `Data Entry` or `Data Button` controllers. | |
+
+
+## MIDI Non-registered Parameters
+
+These parameters can be changed by first using the `Non-registered Parameter` controller to select a specific parameter, then
+using the `Data Entry` or `Data Button` controllers to actually change the parameter's value.
+
+| MIDI NRPN# | Name       | Value Range     | Description                                                               |
+| ---------- | ---------- | --------------- | ------------------------------------------------------------------------- |
+| 10         | Percussion | 0 (off), 1 (on) | Sets whether this channel plays a drum kit instead of a normal instrument |

--- a/docs/MIDI.md
+++ b/docs/MIDI.md
@@ -14,7 +14,7 @@ percussion (the drum kit).
 ## Features
 
 * 24-voice polyphony shared between non-percussion channels
-* 8 additional voices reserved for percussion only channel (channel 10)
+* 8 additional voices reserved for percussion only channel (channels 10/11 by default)
 * Pitch bend
 * AfterTouch
 
@@ -25,10 +25,10 @@ For the list of General MIDI instruments available, see [Wikipedia](https://en.w
 Note that the sound produced for these instruments is a wavetable rather than full-length samples, so they sound more like a retro
 keyboard than the high-fidelity samples you might hear from a modern soft synthesizer.
 
-#### Drum Kit
-The Bank 0 Drum Kit follows the key mapping of the General MIDI program sounds, which can be found
-on [Wikipedia](https://en.wikipedia.org/wiki/General_MIDI#Percussion). Note that some drum sounds may be incomplete or
-not yet supported.
+#### GM-Compatible Drum Kit
+The Bank 0 Drum Kit is a set of custom drum sounds that follows the standard General MIDI note-to-drum mappings, which can be found
+on [Wikipedia](https://en.wikipedia.org/wiki/General_MIDI#Percussion) and is commonly supported by MIDI devices and software. Note
+that some drum sounds may be incomplete or not yet supported.
 
 ### MAGFest Instruments (Bank 1)
 These instruments are mainly basic wave shapes, with some extra goodies thrown in.
@@ -45,7 +45,7 @@ These instruments are mainly basic wave shapes, with some extra goodies thrown i
 |        7 | Square Wave Hit |
 |        8 | Noise Hit       |
 
-#### Drum Kit
+#### Donut Swadge Drum Kit
 The Bank 1 Drum Kit includes a range of noise-based drum sounds originally featured on the [King Donut Swadge](https://swadge.com/donut/).
 
 | Note     | Note Number | Description       |
@@ -86,6 +86,15 @@ fine and coarse adjustment knobs on a real audio device, but some editing softwa
 These parameters can be changed by first using the `Non-registered Parameter` controller to select a specific parameter, then
 using the `Data Entry` or `Data Button` controllers to actually change the parameter's value.
 
-| MIDI NRPN# | Name       | Value Range     | Description                                                               |
-| ---------- | ---------- | --------------- | ------------------------------------------------------------------------- |
-| 10         | Percussion | 0 (off), 1 (on) | Sets whether this channel plays a drum kit instead of a normal instrument |
+| MIDI NRPN# | Name       | Value Range     | Description                                                                |
+| ---------- | ---------- | --------------- | -------------------------------------------------------------------------- |
+| 10         | Percussion | 0 (off), 1 (on) | Sets whether this channel plays a drum kit instead of a pitched instrument |
+
+## MIDI System-Exclusive (SysEx) Parameters
+
+The Swadge does not currently support any SysEx commands of its own, but it does support the following Universal SysEx commands.
+
+| Name       | Data (Hex)                   | Description |
+| ---------- | ---------------------------- | ----------- |
+| GM Enable  | <pre>F0 7E 7F 09 01 F7</pre> | Enables General MIDI Mode. All channels are fully reset, and set to use Bank 0, Program 0 ("Acoustic Grand Piano"), and Channel 10 only set to Percussion mode. |
+| GM Disable | <pre>F0 7E 7F 09 00 F7</pre> | Disables General MIDI Mode. All channels are fully reset, and set to use Bank 1. Channels 1 through 9 are set to use Programs 0 through 8, respectively. Channel 10 is set to Percussion mode, and set to Bank 0 (General MIDI Compatible Drum kit). Channel 11 is set to Percussion mode, and set to Bank 1 (Donut Swadge Drum kit). Channels 12 through 16 **are currently** set to Bank 0, Program 0 ("Acoustic Grand Piano"), but **note** that this may change in the future and is not a guarantee. |

--- a/docs/MIDI.md
+++ b/docs/MIDI.md
@@ -8,8 +8,9 @@ commands are simply ignored and the rest of the file will play normally.
 
 ## Basics
 
-The Swadge's 8-bit audio synthesizer supports up to 16 MIDI channels, with channel 10 reserved for
-percussion (the drum kit).
+The Swadge's 8-bit audio synthesizer supports up to 16 MIDI channels, with channels 10 and 11 reserved for
+percussion (the drum kit). By default, channel 1 through 9 are configured to use the [MAGFest instruments](#MAGPrograms)
+in order.
 
 ## Features
 
@@ -28,9 +29,9 @@ keyboard than the high-fidelity samples you might hear from a modern soft synthe
 #### GM-Compatible Drum Kit
 The Bank 0 Drum Kit is a set of custom drum sounds that follows the standard General MIDI note-to-drum mappings, which can be found
 on [Wikipedia](https://en.wikipedia.org/wiki/General_MIDI#Percussion) and is commonly supported by MIDI devices and software. Note
-that some drum sounds may be incomplete or not yet supported.
+that some drum sounds may be incomplete or not yet supported. This drum kit is available on MIDI Channel 10.
 
-### MAGFest Instruments (Bank 1)
+### MAGFest Instruments (Bank 1) {#MAGPrograms}
 These instruments are mainly basic wave shapes, with some extra goodies thrown in.
 
 | Program# | Name            |
@@ -47,6 +48,7 @@ These instruments are mainly basic wave shapes, with some extra goodies thrown i
 
 #### Donut Swadge Drum Kit
 The Bank 1 Drum Kit includes a range of noise-based drum sounds originally featured on the [King Donut Swadge](https://swadge.com/donut/).
+By default, this drum kit is available on MIDI Channel 11.
 
 | Note     | Note Number | Description       |
 | -------- | ----------- | ----------------- |

--- a/emulator/src/idf/midi_device.c
+++ b/emulator/src/idf/midi_device.c
@@ -25,6 +25,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+// Un-comment to enable printing all received MIDI packets
+//#define DEBUG_MIDI_PACKETS
+
 static uint8_t runningStatus                   = 0;
 static struct platform_midi_driver* midiDriver = NULL;
 
@@ -66,12 +69,14 @@ bool tud_midi_n_packet_read(uint8_t itf, uint8_t packet[4])
     int read = midiDriver ? platform_midi_read(midiDriver, real_packet, sizeof(real_packet)) : 0;
     if (read > 0)
     {
+#ifdef DEBUG_MIDI_PACKETS
         printf("Packet: ");
         for (int i = 0; i < read; i++)
         {
             printf("%hhx, ", real_packet[i]);
         }
         printf("\n");
+#endif
 
         // Normally start reading after the status byte
         int dataOffset = 1;

--- a/emulator/src/idf/midi_device.c
+++ b/emulator/src/idf/midi_device.c
@@ -26,7 +26,7 @@
 #include <stdint.h>
 
 // Un-comment to enable printing all received MIDI packets
-//#define DEBUG_MIDI_PACKETS
+// #define DEBUG_MIDI_PACKETS
 
 static uint8_t runningStatus                   = 0;
 static struct platform_midi_driver* midiDriver = NULL;

--- a/main/midi/midiFileParser.c
+++ b/main/midi/midiFileParser.c
@@ -540,11 +540,17 @@ static bool trackParseNext(midiFileReader_t* reader, midiTrackState_t* track)
 
                 // TODO: Move this to the streaming parser
                 // We'll need to read at least one more byte
-                if (!TRK_REMAIN()) { ERR(); }
+                if (!TRK_REMAIN())
+                {
+                    ERR();
+                }
                 uint16_t manufacturer = *(track->cur++);
                 if (!manufacturer)
                 {
-                    if (TRK_REMAIN() < 2) { ERR(); }
+                    if (TRK_REMAIN() < 2)
+                    {
+                        ERR();
+                    }
                     // A manufacturer ID of 0 means the ID is actually in the next 2 bytes
                     manufacturer = *(track->cur++);
                     manufacturer <<= 7;

--- a/main/midi/midiFileParser.c
+++ b/main/midi/midiFileParser.c
@@ -516,26 +516,6 @@ static bool trackParseNext(midiFileReader_t* reader, midiTrackState_t* track)
                 // A sysex event in a MIDI file is different from one in streaming mode (i.e. USB), because there is no
                 // length byte transmitted in streaming mode, so we need to check the manufacturer length there
 
-                // TODO: Move this to the streaming parser
-                /*
-                // We'll need to read at least one more byte
-                //if (!TRK_REMAIN()) { ERR(); }
-                uint16_t manufacturer = *(track->cur++);
-                if (!manufacturer)
-                {
-                    if (TRK_REMAIN() < 2) { ERR(); }
-                    // A manufacturer ID of 0 means the ID is actually in the next 2 bytes
-                    manufacturer = *(track->cur++);
-                    manufacturer <<= 7;
-                    manufacturer |= *(track->cur++);
-                }
-                else
-                {
-                    // Technically 0x00 0x00 0x41 is considered a different manufacturer from the single-byte value 0x41
-                    // So in that case just put a 1 in the 15th bit that's otherwise unused
-                    manufacturer |= (1 << 15);
-                }*/
-
                 uint32_t sysexLength;
                 read = readVariableLength(track->cur, TRK_REMAIN(), &sysexLength);
                 if (!read)
@@ -554,10 +534,32 @@ static bool trackParseNext(midiFileReader_t* reader, midiTrackState_t* track)
                 track->nextEvent.sysex.data   = track->cur;
                 // If the status is 0xF0, the 0xF0 should be prefixed to the data.
                 track->nextEvent.sysex.prefix = (status == 0xF0) ? 0xF0 : 0x00;
-                // TODO
-                track->nextEvent.sysex.manufacturerId = 0;
 
-                track->cur += sysexLength;
+                // Store the pointer to the end of data so we don't need to do math later
+                const uint8_t* sysexEnd = (track->cur + sysexLength);
+
+                // TODO: Move this to the streaming parser
+                // We'll need to read at least one more byte
+                if (!TRK_REMAIN()) { ERR(); }
+                uint16_t manufacturer = *(track->cur++);
+                if (!manufacturer)
+                {
+                    if (TRK_REMAIN() < 2) { ERR(); }
+                    // A manufacturer ID of 0 means the ID is actually in the next 2 bytes
+                    manufacturer = *(track->cur++);
+                    manufacturer <<= 7;
+                    manufacturer |= *(track->cur++);
+                }
+                else
+                {
+                    // Technically 0x00 0x00 0x41 is considered a different manufacturer from the single-byte value 0x41
+                    // So in that case just put a 1 in the 15th bit that's otherwise unused
+                    manufacturer |= (1 << 15);
+                }
+
+                track->nextEvent.sysex.manufacturerId = manufacturer;
+
+                track->cur = sysexEnd;
             }
             else
             {

--- a/main/midi/midiPlayer.c
+++ b/main/midi/midiPlayer.c
@@ -15,7 +15,7 @@
 #include "cnfs.h"
 
 // Uncomment to enable logging SysEx commands in detail
-//#define DEBUG_SYSEX 1
+// #define DEBUG_SYSEX 1
 
 #define OSC_DITHER
 
@@ -835,7 +835,6 @@ static void handleSysexEvent(midiPlayer_t* player, const midiSysexEvent_t* sysex
     // GM Disable (02)
     // GM2 Enable (03)
     // GM Disable (00) (incorrect but I bet people are doing it because teragonaudio says to)
-    //0000    7e 7f 09 02 f7 
     uint8_t mfrLen = 1;
 
 #ifdef DEBUG_SYSEX
@@ -843,7 +842,7 @@ static void handleSysexEvent(midiPlayer_t* player, const midiSysexEvent_t* sysex
 #endif
 
     const uint8_t* end = sysex->data + sysex->length;
-    
+
     // Determine the length of the manufacturer ID so we know how many bytes to skip for the real data
     if (sysex->manufacturerId & (1 << 15))
     {
@@ -891,7 +890,7 @@ static void handleSysexEvent(midiPlayer_t* player, const midiSysexEvent_t* sysex
     switch (sysex->manufacturerId)
     {
         case MMFR_EDUCATIONAL_USE:
-        break;
+            break;
 
         case MMFR_UNIVERSAL_NON_REAL_TIME:
         case MMFR_UNIVERSAL_REAL_TIME:
@@ -899,7 +898,7 @@ static void handleSysexEvent(midiPlayer_t* player, const midiSysexEvent_t* sysex
             bool realTime = (sysex->manufacturerId == MMFR_UNIVERSAL_REAL_TIME);
 
             // Universal SysEx messages have 127 "channel" values, with 0x7F meaning "Disregard Channel"
-            uint8_t sysexChannel = *dataPtr++;
+            // uint8_t sysexChannel = *dataPtr++;
 
             if (dataPtr >= end)
             {
@@ -930,7 +929,7 @@ static void handleSysexEvent(midiPlayer_t* player, const midiSysexEvent_t* sysex
                     case 0x2:
                     // Notation Information
                     case 0x3:
-                    break;
+                        break;
 
                     // Device Control
                     case 0x4:
@@ -945,7 +944,7 @@ static void handleSysexEvent(midiPlayer_t* player, const midiSysexEvent_t* sysex
 
                             // Master Balance
                             case 2:
-                            break;
+                                break;
 
                             // Master Fine Tuning
                             case 3:
@@ -961,7 +960,7 @@ static void handleSysexEvent(midiPlayer_t* player, const midiSysexEvent_t* sysex
 
                             case 5:
                             default:
-                            break;
+                                break;
                         }
 
                         break;
@@ -984,7 +983,7 @@ static void handleSysexEvent(midiPlayer_t* player, const midiSysexEvent_t* sysex
                     // Mobile Phone Control Message
                     case 0xC:
                     default:
-                    break;
+                        break;
                 }
             }
             else
@@ -1010,7 +1009,7 @@ static void handleSysexEvent(midiPlayer_t* player, const midiSysexEvent_t* sysex
                     case 0x7:
                     // MIDI Tuning Standard
                     case 0x8:
-                    break;
+                        break;
 
                     // General MIDI
                     case 0x9:
@@ -1020,8 +1019,10 @@ static void handleSysexEvent(midiPlayer_t* player, const midiSysexEvent_t* sysex
                             case 0:
                             {
                                 // NOTE: This value is NOT defined by the MIDI spec
-                                // However, some resources incorrectly claim that a value of `0` for sub-ID 2 is the value for a "GM Off" event (with `1` being "GM On"),
-                                // even though a value of `2` is specified for `GM Off`, so it is possible that a `0` value will be sent with the intent to disable GM.
+                                // However, some resources incorrectly claim that a value of `0` for sub-ID 2 is the
+                                // value for a "GM Off" event (with `1` being "GM On"), even though a value of `2` is
+                                // specified for `GM Off`, so it is possible that a `0` value will be sent with the
+                                // intent to disable GM.
                                 midiGmOff(player);
                                 break;
                             }
@@ -1043,8 +1044,7 @@ static void handleSysexEvent(midiPlayer_t* player, const midiSysexEvent_t* sysex
                             // General MIDI 2 On (Unsupported)
                             case 3:
                             default:
-                            break;
-
+                                break;
                         }
                         break;
                     }
@@ -1068,7 +1068,7 @@ static void handleSysexEvent(midiPlayer_t* player, const midiSysexEvent_t* sysex
                     // ACK
                     case 0x7F:
                     default:
-                    break;
+                        break;
                 }
             }
 
@@ -1427,7 +1427,7 @@ void midiGmOff(midiPlayer_t* player)
         // Also enable percussion on channel 11 (index 10) with an alternate drum kit
         chan->percussion = (9 == chanIdx || 10 == chanIdx);
         // Set bank 1 (MAGFest sounds) for everything except the first drumkit on 10
-        chan->bank       = (9 == chanIdx) ? 0 : 1;
+        chan->bank = (9 == chanIdx) ? 0 : 1;
 
         switch (chanIdx)
         {

--- a/main/midi/midiPlayer.c
+++ b/main/midi/midiPlayer.c
@@ -1162,7 +1162,7 @@ void midiPlayerInit(midiPlayer_t* player)
 void midiPlayerReset(midiPlayer_t* player)
 {
     midiAllSoundOff(player);
-    midiGmOn(player);
+    midiGmOff(player);
 
     // We need the tempo to not be zero, so set it to the default of 120BPM until we get a tempo event
     // 120 BPM == 500,000 microseconds per quarter note

--- a/main/midi/midiPlayer.h
+++ b/main/midi/midiPlayer.h
@@ -892,7 +892,7 @@ uint16_t midiGetControlValue14bit(midiPlayer_t* player, uint8_t channel, midiCon
  * @param player The MIDI player
  * @param channel The channel to set the parameter on
  * @param registered true if param refers to a registered parameter number and false if it refers to a non-registered
- * parameter
+ * @param param The registered or non-registered MIDI parameter to set the value of
  * @param value The 14-bit value to set the parameter to
  */
 void midiSetParameter(midiPlayer_t* player, uint8_t channel, bool registered, uint16_t param, uint16_t value);
@@ -903,7 +903,7 @@ void midiSetParameter(midiPlayer_t* player, uint8_t channel, bool registered, ui
  * @param player The MIDI player
  * @param channel The channel to retrieve the parameter from
  * @param registered true if param refers to a registered parameter number and false if it refers to a non-registered
- * parameter
+ * @param param The registered or non-registered MIDI parameter number to retrieve the value for
  * @return The current 14-bit value of the given registered or non-registered parameter, or 0 if the parameter is
  * unsupported
  */

--- a/main/midi/midiPlayer.h
+++ b/main/midi/midiPlayer.h
@@ -584,6 +584,12 @@ typedef struct
     /// @brief The ID of the program (timbre) set for this channel
     uint8_t program;
 
+    /// @brief Whether selectedParameter represents a registered or non-registered parameter
+    bool registeredParameter;
+
+    /// @brief The ID of the currently selected registered or non-registered parameter
+    uint16_t selectedParameter;
+
     /// @brief The actual current timbre definition which the program ID corresponds to
     midiTimbre_t timbre;
 
@@ -869,6 +875,29 @@ uint8_t midiGetControlValue(midiPlayer_t* player, uint8_t channel, midiControl_t
  * @return uint16_t The value of the specified control, or 0 if the specified controller is not implemented
  */
 uint16_t midiGetControlValue14bit(midiPlayer_t* player, uint8_t channel, midiControl_t control);
+
+/**
+ * @brief Set a registered or non-registered parameter value
+ *
+ * @param player The MIDI player
+ * @param channel The channel to set the parameter on
+ * @param registered true if param refers to a registered parameter number and false if it refers to a non-registered
+ * parameter
+ * @param value The 14-bit value to set the parameter to
+ */
+void midiSetParameter(midiPlayer_t* player, uint8_t channel, bool registered, uint16_t param, uint16_t value);
+
+/**
+ * @brief Get the value of a registered or non-registered parameter
+ *
+ * @param player The MIDI player
+ * @param channel The channel to retrieve the parameter from
+ * @param registered true if param refers to a registered parameter number and false if it refers to a non-registered
+ * parameter
+ * @return The current 14-bit value of the given registered or non-registered parameter, or 0 if the parameter is
+ * unsupported
+ */
+uint16_t midiGetParameterValue(midiPlayer_t* player, uint8_t channel, bool registered, uint16_t param);
 
 /**
  * @brief Set the pitch wheel value on a given MIDI channel

--- a/main/midi/midiPlayer.h
+++ b/main/midi/midiPlayer.h
@@ -334,6 +334,16 @@ typedef enum
     MCC_POLY_OPERATION = 127,
 } midiControl_t;
 
+/**
+ * @brief Values that can be directly compared against midiSysexEvent_t::manufacturerId
+ */
+typedef enum
+{
+    MMFR_EDUCATIONAL_USE         = 0x807D,
+    MMFR_UNIVERSAL_NON_REAL_TIME = 0x807E,
+    MMFR_UNIVERSAL_REAL_TIME     = 0x807F,
+} midiManufacturerId_t;
+
 //==============================================================================
 // Structs
 //==============================================================================

--- a/main/modes/music/usbsynth/mode_synth.c
+++ b/main/modes/music/usbsynth/mode_synth.c
@@ -1514,7 +1514,8 @@ static void synthEnterMode(void)
                 {
                     for (int blobIdx = 0; blobIdx < sd->synthConfig.controlCounts; blobIdx++)
                     {
-                        synthControlConfig_t* copy = (synthControlConfig_t*)heap_caps_malloc(sizeof(synthControlConfig_t), MALLOC_CAP_SPIRAM);
+                        synthControlConfig_t* copy
+                            = (synthControlConfig_t*)heap_caps_malloc(sizeof(synthControlConfig_t), MALLOC_CAP_SPIRAM);
                         if (copy)
                         {
                             memcpy(copy, &configs[blobIdx], sizeof(synthControlConfig_t));
@@ -2402,7 +2403,8 @@ static void addChannelsMenu(menu_t* menu, const synthConfig_t* config)
     addSingleItemToMenu(menu, menuItemResetAll);
     wheelMenuSetItemInfo(sd->wheelMenu, menuItemResetAll, &sd->resetImage, rotTopMenu++, NO_SCROLL);
 
-    addSettingsOptionsItemToMenu(menu, menuItemGm, menuItemOffOnOptions, menuItemGmValues, ARRAY_SIZE(menuItemGmValues), &menuItemGmBounds, sd->gmMode);
+    addSettingsOptionsItemToMenu(menu, menuItemGm, menuItemOffOnOptions, menuItemGmValues, ARRAY_SIZE(menuItemGmValues),
+                                 &menuItemGmBounds, sd->gmMode);
     wheelMenuSetItemInfo(sd->wheelMenu, menuItemGm, NULL, rotTopMenu++, SCROLL_HORIZ_R);
     wheelMenuSetItemTextIcon(sd->wheelMenu, menuItemGm, "GM");
 }

--- a/main/modes/music/usbsynth/mode_synth.c
+++ b/main/modes/music/usbsynth/mode_synth.c
@@ -18,6 +18,8 @@
 #include "cnfs_image.h"
 #include "ctype.h"
 
+#include <esp_heap_caps.h>
+
 #include "midiPlayer.h"
 #include "midiFileParser.h"
 #include "midiUsb.h"
@@ -1384,7 +1386,7 @@ static synthData_t* sd;
 
 static void synthEnterMode(void)
 {
-    sd = calloc(1, sizeof(synthData_t));
+    sd = heap_caps_calloc(1, sizeof(synthData_t), MALLOC_CAP_SPIRAM);
     loadFont("ibm_vga8.font", &sd->font, true);
     loadFont("sonic.font", &sd->betterFont, true);
     makeOutlineFont(&sd->betterFont, &sd->betterOutline, true);
@@ -1512,7 +1514,7 @@ static void synthEnterMode(void)
                 {
                     for (int blobIdx = 0; blobIdx < sd->synthConfig.controlCounts; blobIdx++)
                     {
-                        synthControlConfig_t* copy = (synthControlConfig_t*)malloc(sizeof(synthControlConfig_t));
+                        synthControlConfig_t* copy = (synthControlConfig_t*)heap_caps_malloc(sizeof(synthControlConfig_t), MALLOC_CAP_SPIRAM);
                         if (copy)
                         {
                             memcpy(copy, &configs[blobIdx], sizeof(synthControlConfig_t));
@@ -1529,7 +1531,7 @@ static void synthEnterMode(void)
         size_t savedNameLen;
         if (readNvsBlob(nvsKeyLastSong, NULL, &savedNameLen))
         {
-            sd->filenameBuf = malloc(savedNameLen < 128 ? 128 : savedNameLen + 1);
+            sd->filenameBuf = heap_caps_malloc(savedNameLen < 128 ? 128 : savedNameLen + 1, MALLOC_CAP_SPIRAM);
 
             if (readNvsBlob(nvsKeyLastSong, sd->filenameBuf, &savedNameLen))
             {
@@ -2092,7 +2094,7 @@ static void synthSaveControl(uint8_t channel, uint8_t control, uint8_t value)
     }
 
     // Not found, add one
-    synthControlConfig_t* conf = calloc(1, sizeof(synthControlConfig_t));
+    synthControlConfig_t* conf = heap_caps_calloc(1, sizeof(synthControlConfig_t), MALLOC_CAP_SPIRAM);
     if (conf)
     {
         conf->control             = control;
@@ -2573,7 +2575,7 @@ static void preloadLyrics(karaokeInfo_t* karInfo, const midiFile_t* midiFile)
 
                 // TODO we could save a couple bytes if we parsed the file an additional time to check how many events
                 // there are in total...
-                midiTextInfo_t* info = (midiTextInfo_t*)malloc(sizeof(midiTextInfo_t));
+                midiTextInfo_t* info = (midiTextInfo_t*)heap_caps_malloc(sizeof(midiTextInfo_t), MALLOC_CAP_SPIRAM);
 
                 if (info)
                 {
@@ -4008,7 +4010,7 @@ static void midiTextCallback(metaEventType_t type, const char* text, uint32_t le
         return;
     }
 
-    midiTextInfo_t* info = (midiTextInfo_t*)malloc(sizeof(midiTextInfo_t));
+    midiTextInfo_t* info = (midiTextInfo_t*)heap_caps_malloc(sizeof(midiTextInfo_t), MALLOC_CAP_SPIRAM);
 
     if (info)
     {
@@ -4176,7 +4178,7 @@ static void synthMenuCb(const char* label, bool selected, uint32_t value)
             sd->screen = SS_FILE_SELECT;
             if (!sd->filenameBuf)
             {
-                sd->filenameBuf = calloc(1, 128);
+                sd->filenameBuf = heap_caps_calloc(1, 128, MALLOC_CAP_SPIRAM);
             }
 
             if (!sd->filenameBuf)


### PR DESCRIPTION
### Description

Adds support for setting MIDI registered and non-registered parameters. Mostly these aren't supported but non-registered parameters are the one place we can stick custom commands without registering a SysEx ID with the MMA.

Also adds support for "Universal SysEx" commands that are non-manufacturer-specific and defined in the MIDI standard.  Only the General MIDI Enable/Disable commands are supported now.

Adds the GM Enable/Disable setting to the MIDI Player mode, and also switches the mode to using SPIRAM for everything.

And finally, the default instruments are changed to be the chiptune-y MAGFest sounds, pre-selected on channels to match the MIDI file template, and all this included in the docs.

### Test Instructions

Tested using the switch in the MIDI player mode as well as using test MIDI files for [GM Enable](https://github.com/jazz-soft/test-midi-files/blob/main/midi/test-sysex-7e-09-01-gm1-enable.mid) and [GM Disable](https://github.com/jazz-soft/test-midi-files/blob/main/midi/test-sysex-7e-09-02-gm-disable.mid). The commands don't work over streaming mode in the emulator or the real swadge but that's a tinyusb thing to figure out later, it's allegedly possible...

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
