### PR TITLE
Add FreeDesktop config files for native support in graphical desktop environments

### DIFF
--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -55,6 +55,9 @@ jobs:
             emu_artifacts:
               - swadge_emulator
               - version.txt
+              - install.sh
+              - icon.png
+              - SwadgeEmulator.desktop
             idf_install: ~/.espressif
 
     runs-on: ${{ matrix.runner }}
@@ -168,6 +171,13 @@ jobs:
       if: matrix.emulator && matrix.family == 'osx'
       run: |
         make SwadgeEmulator.app
+
+    - name: Create Linux FreeDesktop files
+      if: matrix.emulator && matrix.family == 'linux'
+      run: |
+        cp emulator/resources/install.sh .
+        cp emulator/resources/icon.png .
+        cp emulator/resources/SwadgeEmulator.desktop .
 
     - name: Create Emulator zip
       if: matrix.emulator && matrix.family != 'windows'

--- a/docs/EMULATOR.md
+++ b/docs/EMULATOR.md
@@ -22,7 +22,16 @@ wireless connection.
 
 The Linux version of the emulator does not require any other software to operate. Simply extract the
 `.zip` file anywhere you like and run the `swadge_emulator` program, either by opening it from your
-file browser or by running `./swadge_emulator` from the command-line.
+file browser or by running `./swadge_emulator` from the command-line. The Linux emulator includes a
+script, `install.sh`, which can be run to install the Swadge Emulator as a desktop application, which
+will allow you to open the emulator directly from many desktop environments, and to asssociate the
+emulator with MIDI files using the "Open with..." option in your file browser. If you do not want these
+features, there is no need to run the script. You will need to run this script again if you download a
+new version of the emulator. By default, the installation script will install to `~/.local`, but you
+can specify an alternate installation root such as `/usr/local` by passing it as an argument to
+the `install.sh` script:
+
+    ./install.sh /usr/local
 
 ### Mac
 

--- a/docs/EMULATOR.md
+++ b/docs/EMULATOR.md
@@ -266,7 +266,9 @@ time.
 
 MIDI Files (`.mid`, `.midi`, and `.kar`) can be played in directly by passing the name of
 the MIDI file as a command-line argument to the Swadge Emulator. On Windows, you should also be able
-to drag a MIDI file on top of `SwadgeEmulator.exe` to play it.
+to drag a MIDI file on top of `SwadgeEmulator.exe` to play it. On Linux, you should be able to open
+MIDI files with the emulator using your file browser's "Open with..." option after running the included
+install script.
 
 The Swadge Emulator includes MIDI support, which simulates the USB-MIDI behavior of the real Swadge
 using the system MIDI implementation. Note that MIDI implementation and behavior will vary between

--- a/emulator/resources/SwadgeEmulator.desktop
+++ b/emulator/resources/SwadgeEmulator.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Swadge Emulator
+GenericName=Swadge Emulator
+Comment=Emulate the MAGFest Swadge
+Exec=$ROOT/bin/swadge_emulator %U
+Terminal=false
+Type=Application
+StartupNotify=true
+MimeType=audio/midi;audio/x-midi;
+Icon=$ROOT/share/icons/SwadgeEmulator/icon.png
+Categories=Game;Emulator;AudioVideo;Audio;Midi;Player;Development;

--- a/emulator/resources/install.sh
+++ b/emulator/resources/install.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+set -x
+
+if [ -e swadge_emulator ]; then
+    BIN_SRC="swadge_emulator"
+elif [ -e ../../swadge_emulator ]; then
+    BIN_SRC="../../swadge_emulator"
+else
+    echo "Error: install file 'swadge_emulator' not found! Are you running this script from the correct directory?"
+    exit 1
+fi
+
+if [ -e SwadgeEmulator.desktop ]; then
+    DESKTOP_SRC="SwadgeEmulator.desktop"
+elif [ -e emulator/resources/SwadgeEmulator.desktop ]; then
+    DESKTOP_SRC="emulator/resources/SwadgeEmulator.desktop"
+else
+    echo "Error: install file 'SwadgeEmulator.desktop' not found! Are you running this script from the correct directory?"
+    exit 1
+fi
+
+if [ -e icon.png ]; then
+    ICON_SRC="icon.png"
+elif [ -e emulator/resources/icon.png ]; then
+    ICON_SRC="emulator/resources/icon.png"
+else
+    echo "Error: install file 'ico.png' not found! Are you running this script from the correct directory?"
+fi
+
+INSTALL_DIR="${HOME}/.local"
+
+if [ "$#" -gt "0" ]; then
+    INSTALL_DIR="${1}"
+fi
+
+echo "Installing the Swadge Emulator to: ${INSTALL_DIR}"
+
+mkdir -p "${INSTALL_DIR}/bin" "${INSTALL_DIR}/share/icons/SwadgeEmulator" "${INSTALL_DIR}/share/applications"
+
+cp "${BIN_SRC}" "${INSTALL_DIR}/bin/swadge_emulator"
+cp "${ICON_SRC}" "${INSTALL_DIR}/share/icons/SwadgeEmulator/icon.png"
+sed "s,\$ROOT,${INSTALL_DIR},g" "${DESKTOP_SRC}" > "${INSTALL_DIR}/share/applications/SwadgeEmulator.desktop"
+
+if ! [[ ":$PATH:" == *":$INSTALL_DIR/bin:"* ]]; then
+    echo "WARNING: ${INSTALL_DIR}/bin is not in your PATH!"
+    echo "    If you want to be able to start the Swadge Emulator from the command-line,"
+    echo "    you can run this command to update your PATH for this session,"
+    echo "    or add it to a file like ~/.bash_profile:"
+    echo
+    echo "        export PATH=\"\$PATH:${INSTALL_DIR}/bin\""
+    echo
+fi
+
+echo
+echo "Installation complete!"

--- a/emulator/resources/install.sh
+++ b/emulator/resources/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
-set -x
+# Uncomment this to print all script lines
+# set -x
 
 if [ -e swadge_emulator ]; then
     BIN_SRC="swadge_emulator"


### PR DESCRIPTION
### Description

Adds a [FreeDesktop .desktop file](https://wiki.archlinux.org/title/Desktop_entries) for the Linux emulator, and a script to be included with the emulator download that handles installing it and its related files.

### Test Instructions

It works on my machine! The install script should work if you run it from the download (with `swadge_emulator`, `icon.png`, and `SwadgeEmulator.desktop`), the repository root, or the `emulator/resources` directory inside the repository. If you try to run it from somewhere else it should complain about the files and give you a hint to fix it, and exit without doing anything else. Installing to alternate locations, e.g. `/usr/local`, should work and instructions are included in the emulator docs. On probably most Linux desktop environments (tested on Gnome), after installing you can right-click a MIDI file and use "Open with..." to play the file, and even set it as the default application for MIDI files.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
