### PR TITLE
Tunernome

### DIFF
--- a/components/hdw-dac/hdw-dac.c
+++ b/components/hdw-dac/hdw-dac.c
@@ -70,42 +70,46 @@ static bool IRAM_ATTR dac_on_convert_done_callback(dac_continuous_handle_t handl
  */
 void initDac(dac_channel_mask_t channel, gpio_num_t shdn_gpio, fnDacCallback_t cb)
 {
-    /* Save the callback */
-    dacCb = cb;
+    // If the DAC isn't initialized
+    if (!dac_handle)
+    {
+        /* Save the callback */
+        dacCb = cb;
 
-    /* Configure the DAC */
-    dac_continuous_config_t cont_cfg = {
-        .chan_mask = channel,                // DAC_CHANNEL_MASK_CH0 is GPIO_NUM_17, DAC_CHANNEL_MASK_CH1 is GPIO_NUM_18
-        .desc_num  = DMA_DESCRIPTORS,        // The number of DMA descriptors
-        .buf_size  = DAC_BUF_SIZE,           // The size of each MDA buffer
-        .freq_hz   = DAC_SAMPLE_RATE_HZ,     // The frequency of DAC conversion
-        .offset    = 0,                      // DC Offset automatically applied
-        .clk_src   = DAC_DIGI_CLK_SRC_APB,   // DAC_DIGI_CLK_SRC_APB is 77hz->MHz and always available
+        /* Configure the DAC */
+        dac_continuous_config_t cont_cfg = {
+            .chan_mask = channel,            // DAC_CHANNEL_MASK_CH0 is GPIO_NUM_17, DAC_CHANNEL_MASK_CH1 is GPIO_NUM_18
+            .desc_num  = DMA_DESCRIPTORS,    // The number of DMA descriptors
+            .buf_size  = DAC_BUF_SIZE,       // The size of each MDA buffer
+            .freq_hz   = DAC_SAMPLE_RATE_HZ, // The frequency of DAC conversion
+            .offset    = 0,                  // DC Offset automatically applied
+            .clk_src   = DAC_DIGI_CLK_SRC_APB, // DAC_DIGI_CLK_SRC_APB is 77hz->MHz and always available
                                              // DAC_DIGI_CLK_SRC_APLL is 6Hz -> MHz but may be used by other peripherals
-        .chan_mode = DAC_CHANNEL_MODE_SIMUL, // Doesn't matter for single channel output
-    };
+            .chan_mode = DAC_CHANNEL_MODE_SIMUL, // Doesn't matter for single channel output
+        };
 
-    /* Allocate continuous channels */
-    ESP_ERROR_CHECK(dac_continuous_new_channels(&cont_cfg, &dac_handle));
+        /* Allocate continuous channels */
+        ESP_ERROR_CHECK(dac_continuous_new_channels(&cont_cfg, &dac_handle));
 
-    /* Create a queue to transport the interrupt event data */
-    dacIsrQueue = xQueueCreate(DMA_DESCRIPTORS, sizeof(dac_event_data_t));
+        /* Create a queue to transport the interrupt event data */
+        dacIsrQueue = xQueueCreate(DMA_DESCRIPTORS, sizeof(dac_event_data_t));
 
-    /* Register callbacks for conversion events */
-    dac_event_callbacks_t cbs = {
-        .on_convert_done = dac_on_convert_done_callback,
-        .on_stop         = NULL,
-    };
-    ESP_ERROR_CHECK(dac_continuous_register_event_callback(dac_handle, &cbs, dacIsrQueue));
+        /* Register callbacks for conversion events */
+        dac_event_callbacks_t cbs = {
+            .on_convert_done = dac_on_convert_done_callback,
+            .on_stop         = NULL,
+        };
+        ESP_ERROR_CHECK(dac_continuous_register_event_callback(dac_handle, &cbs, dacIsrQueue));
 
-    /* Initialize the GPIO of shutdown pin */
-    shdnGpio                       = shdn_gpio;
-    gpio_config_t shdn_gpio_config = {
-        .mode         = GPIO_MODE_OUTPUT,
-        .pin_bit_mask = 1ULL << shdn_gpio,
-    };
-    ESP_ERROR_CHECK(gpio_config(&shdn_gpio_config));
-    ESP_ERROR_CHECK(gpio_set_level(shdn_gpio, 0));
+        /* Initialize the GPIO of shutdown pin */
+        shdnGpio                       = shdn_gpio;
+        gpio_config_t shdn_gpio_config = {
+            .mode         = GPIO_MODE_OUTPUT,
+            .pin_bit_mask = 1ULL << shdn_gpio,
+        };
+        ESP_ERROR_CHECK(gpio_config(&shdn_gpio_config));
+        ESP_ERROR_CHECK(gpio_set_level(shdn_gpio, 0));
+    }
 }
 
 /**
@@ -113,15 +117,20 @@ void initDac(dac_channel_mask_t channel, gpio_num_t shdn_gpio, fnDacCallback_t c
  */
 void deinitDac(void)
 {
-    /* Stop the DAC */
-    dacStop();
+    if (dac_handle)
+    {
+        /* Stop the DAC */
+        dacStop();
 
-    /* Free resources */
-    ESP_ERROR_CHECK(dac_continuous_del_channels(dac_handle));
-    vQueueDelete(dacIsrQueue);
+        /* Free resources */
+        ESP_ERROR_CHECK(dac_continuous_del_channels(dac_handle));
+        dac_handle = NULL;
+        vQueueDelete(dacIsrQueue);
+        dacIsrQueue = NULL;
 
-    /* NULL the callback */
-    dacCb = NULL;
+        /* NULL the callback */
+        dacCb = NULL;
+    }
 }
 
 /**
@@ -129,9 +138,12 @@ void deinitDac(void)
  */
 void dacStart(void)
 {
-    /* Enable and start the continuous channels */
-    ESP_ERROR_CHECK(dac_continuous_enable(dac_handle));
-    ESP_ERROR_CHECK(dac_continuous_start_async_writing(dac_handle));
+    if (dac_handle)
+    {
+        /* Enable and start the continuous channels */
+        ESP_ERROR_CHECK(dac_continuous_enable(dac_handle));
+        ESP_ERROR_CHECK(dac_continuous_start_async_writing(dac_handle));
+    }
 }
 
 /**
@@ -139,9 +151,12 @@ void dacStart(void)
  */
 void dacStop(void)
 {
-    /* Stop and disable the continuous channels */
-    ESP_ERROR_CHECK(dac_continuous_stop_async_writing(dac_handle));
-    ESP_ERROR_CHECK(dac_continuous_disable(dac_handle));
+    if (dac_handle)
+    {
+        /* Stop and disable the continuous channels */
+        ESP_ERROR_CHECK(dac_continuous_stop_async_writing(dac_handle));
+        ESP_ERROR_CHECK(dac_continuous_disable(dac_handle));
+    }
 }
 
 /**
@@ -149,7 +164,7 @@ void dacStop(void)
  */
 void dacPoll(void)
 {
-    if (NULL != dacIsrQueue)
+    if (dac_handle)
     {
         /* If there is an event to receive, receive it */
         dac_event_data_t evt_data;

--- a/components/hdw-mic/hdw-mic.c
+++ b/components/hdw-mic/hdw-mic.c
@@ -24,53 +24,57 @@ static adc_continuous_handle_t adc_handle = NULL;
  */
 void initMic(gpio_num_t gpio)
 {
-    adc_unit_t unit;
-    adc_channel_t channel;
-    if (ESP_OK == adc_continuous_io_to_channel(gpio, &unit, &channel))
+    // If the mic isn't initalized
+    if (!adc_handle)
     {
-        // Configure the continuous ADC read sizes
-        adc_continuous_handle_cfg_t adc_config = {
-            .max_store_buf_size = 1024,
-            .conv_frame_size    = ADC_READ_LEN,
-        };
-        ESP_ERROR_CHECK(adc_continuous_new_handle(&adc_config, &adc_handle));
-
-        // Pick the conversion mode based on the given channels.
-        // This works because, ADC_CONV_BOTH_UNIT == (ADC_CONV_SINGLE_UNIT_1 | ADC_CONV_SINGLE_UNIT_2)
-        adc_digi_convert_mode_t conv = 0;
-        switch (unit)
+        adc_unit_t unit;
+        adc_channel_t channel;
+        if (ESP_OK == adc_continuous_io_to_channel(gpio, &unit, &channel))
         {
-            case ADC_UNIT_1:
+            // Configure the continuous ADC read sizes
+            adc_continuous_handle_cfg_t adc_config = {
+                .max_store_buf_size = 1024,
+                .conv_frame_size    = ADC_READ_LEN,
+            };
+            ESP_ERROR_CHECK(adc_continuous_new_handle(&adc_config, &adc_handle));
+
+            // Pick the conversion mode based on the given channels.
+            // This works because, ADC_CONV_BOTH_UNIT == (ADC_CONV_SINGLE_UNIT_1 | ADC_CONV_SINGLE_UNIT_2)
+            adc_digi_convert_mode_t conv = 0;
+            switch (unit)
             {
-                conv = ADC_CONV_SINGLE_UNIT_1;
-                break;
+                case ADC_UNIT_1:
+                {
+                    conv = ADC_CONV_SINGLE_UNIT_1;
+                    break;
+                }
+                case ADC_UNIT_2:
+                {
+                    conv = ADC_CONV_SINGLE_UNIT_2;
+                    break;
+                }
             }
-            case ADC_UNIT_2:
-            {
-                conv = ADC_CONV_SINGLE_UNIT_2;
-                break;
-            }
+
+            // Configure the polling frequency, conversion mode, and data format
+            adc_continuous_config_t dig_cfg = {
+                .sample_freq_hz = ADC_SAMPLE_RATE_HZ,
+                .conv_mode      = conv,
+                .format         = ADC_DIGI_OUTPUT_FORMAT_TYPE1,
+            };
+
+            adc_digi_pattern_config_t adc_pattern[SOC_ADC_PATT_LEN_MAX] = {0};
+
+            // Configure the ADC pattern. We only configure a single channel
+            adc_pattern[0].atten     = ADC_ATTEN_DB_12;
+            adc_pattern[0].channel   = channel;
+            adc_pattern[0].unit      = unit;
+            adc_pattern[0].bit_width = SOC_ADC_DIGI_MAX_BITWIDTH;
+
+            // Set the patterns
+            dig_cfg.pattern_num = 1;
+            dig_cfg.adc_pattern = adc_pattern;
+            ESP_ERROR_CHECK(adc_continuous_config(adc_handle, &dig_cfg));
         }
-
-        // Configure the polling frequency, conversion mode, and data format
-        adc_continuous_config_t dig_cfg = {
-            .sample_freq_hz = ADC_SAMPLE_RATE_HZ,
-            .conv_mode      = conv,
-            .format         = ADC_DIGI_OUTPUT_FORMAT_TYPE1,
-        };
-
-        adc_digi_pattern_config_t adc_pattern[SOC_ADC_PATT_LEN_MAX] = {0};
-
-        // Configure the ADC pattern. We only configure a single channel
-        adc_pattern[0].atten     = ADC_ATTEN_DB_12;
-        adc_pattern[0].channel   = channel;
-        adc_pattern[0].unit      = unit;
-        adc_pattern[0].bit_width = SOC_ADC_DIGI_MAX_BITWIDTH;
-
-        // Set the patterns
-        dig_cfg.pattern_num = 1;
-        dig_cfg.adc_pattern = adc_pattern;
-        ESP_ERROR_CHECK(adc_continuous_config(adc_handle, &dig_cfg));
     }
 }
 
@@ -79,7 +83,10 @@ void initMic(gpio_num_t gpio)
  */
 void startMic(void)
 {
-    ESP_ERROR_CHECK(adc_continuous_start(adc_handle));
+    if (adc_handle)
+    {
+        ESP_ERROR_CHECK(adc_continuous_start(adc_handle));
+    }
 }
 
 /**
@@ -92,25 +99,29 @@ void startMic(void)
  */
 uint32_t loopMic(uint16_t* outSamples, uint32_t outSamplesMax)
 {
-    // Read the continuous ADC to this memory
-    uint8_t result[ADC_READ_LEN];
-    uint32_t ret_num = 0;
-
-    // Condition the read samples for return
-    uint32_t samplesRead = 0;
-    if (adc_continuous_read(adc_handle, result, ADC_READ_LEN, &ret_num, 0) == ESP_OK)
+    if (adc_handle)
     {
-        // Loop, but don't go over the number of read samples or number of samples to return
-        for (int i = 0; (i < ret_num) && (samplesRead < outSamplesMax); i += SOC_ADC_DIGI_RESULT_BYTES)
-        {
-            // ADC_DIGI_OUTPUT_FORMAT_TYPE1 is specified in continuous_adc_init()
-            *(outSamples++) = ((adc_digi_output_data_t*)(&result[i]))->type1.data;
-            samplesRead++;
-        }
-    }
+        // Read the continuous ADC to this memory
+        uint8_t result[ADC_READ_LEN];
+        uint32_t ret_num = 0;
 
-    // Return the number of samples read
-    return samplesRead;
+        // Condition the read samples for return
+        uint32_t samplesRead = 0;
+        if (adc_continuous_read(adc_handle, result, ADC_READ_LEN, &ret_num, 0) == ESP_OK)
+        {
+            // Loop, but don't go over the number of read samples or number of samples to return
+            for (int i = 0; (i < ret_num) && (samplesRead < outSamplesMax); i += SOC_ADC_DIGI_RESULT_BYTES)
+            {
+                // ADC_DIGI_OUTPUT_FORMAT_TYPE1 is specified in continuous_adc_init()
+                *(outSamples++) = ((adc_digi_output_data_t*)(&result[i]))->type1.data;
+                samplesRead++;
+            }
+        }
+
+        // Return the number of samples read
+        return samplesRead;
+    }
+    return 0;
 }
 
 /**
@@ -118,7 +129,10 @@ uint32_t loopMic(uint16_t* outSamples, uint32_t outSamplesMax)
  */
 void stopMic(void)
 {
-    ESP_ERROR_CHECK(adc_continuous_stop(adc_handle));
+    if (adc_handle)
+    {
+        ESP_ERROR_CHECK(adc_continuous_stop(adc_handle));
+    }
 }
 
 /**
@@ -126,6 +140,10 @@ void stopMic(void)
  */
 void deinitMic(void)
 {
-    stopMic();
-    ESP_ERROR_CHECK(adc_continuous_deinit(adc_handle));
+    if (adc_handle)
+    {
+        stopMic();
+        ESP_ERROR_CHECK(adc_continuous_deinit(adc_handle));
+        adc_handle = NULL;
+    }
 }

--- a/main/midi/midiFileParser.c
+++ b/main/midi/midiFileParser.c
@@ -1023,23 +1023,26 @@ void* globalMidiSave(void)
     for (int i = 0; i < NUM_GLOBAL_PLAYERS; i++)
     {
         midiPlayer_t* player = globalMidiPlayerGet(i);
-        memcpy(&saveState[i].player, player, sizeof(midiPlayer_t));
-
-        if (player->reader.file != NULL)
+        if (NULL != player)
         {
-            saveState[i].trackCount = player->reader.file->trackCount;
-            saveState[i].trackStates
-                = heap_caps_calloc(saveState[i].trackCount, sizeof(midiTrackState_t), MALLOC_CAP_SPIRAM);
+            memcpy(&saveState[i].player, player, sizeof(midiPlayer_t));
 
-            // Overwrite the copy with the newly allocated pointer, since the current one may be free'd
-            saveState[i].player.reader.states = saveState[i].trackStates;
-
-            for (int trackIdx = 0; trackIdx < saveState[i].trackCount; trackIdx++)
+            if (player->reader.file != NULL)
             {
-                const midiTrackState_t* stateOrig = &player->reader.states[trackIdx];
-                midiTrackState_t* stateCopy       = &saveState[i].trackStates[trackIdx];
+                saveState[i].trackCount = player->reader.file->trackCount;
+                saveState[i].trackStates
+                    = heap_caps_calloc(saveState[i].trackCount, sizeof(midiTrackState_t), MALLOC_CAP_SPIRAM);
 
-                memcpy(stateCopy, stateOrig, sizeof(midiTrackState_t));
+                // Overwrite the copy with the newly allocated pointer, since the current one may be free'd
+                saveState[i].player.reader.states = saveState[i].trackStates;
+
+                for (int trackIdx = 0; trackIdx < saveState[i].trackCount; trackIdx++)
+                {
+                    const midiTrackState_t* stateOrig = &player->reader.states[trackIdx];
+                    midiTrackState_t* stateCopy       = &saveState[i].trackStates[trackIdx];
+
+                    memcpy(stateCopy, stateOrig, sizeof(midiTrackState_t));
+                }
             }
         }
     }
@@ -1054,9 +1057,12 @@ void globalMidiRestore(void* data)
     for (int i = 0; i < NUM_GLOBAL_PLAYERS; i++)
     {
         midiPlayer_t* player = globalMidiPlayerGet(i);
-        midiPlayerReset(player);
+        if (NULL != player)
+        {
+            midiPlayerReset(player);
 
-        memcpy(player, &saveState[i].player, sizeof(midiPlayer_t));
+            memcpy(player, &saveState[i].player, sizeof(midiPlayer_t));
+        }
     }
 
     // Do not free any of the individual save state data, since it's now just the real data

--- a/main/midi/midiPlayer.c
+++ b/main/midi/midiPlayer.c
@@ -88,7 +88,6 @@ static const uint8_t oscDither[] = {
 // Represents that no voice has been allocated to the instrument, within the special states bitmap
 #define VOICE_FREE (0x3F)
 
-static bool globalPlayerInit       = false;
 static midiPlayer_t* globalPlayers = NULL;
 
 static uint32_t allocVoice(const voiceStates_t* states, uint8_t voiceCount);
@@ -2396,10 +2395,9 @@ void midiSeek(midiPlayer_t* player, uint32_t ticks)
 
 void initGlobalMidiPlayer(void)
 {
-    if (!globalPlayerInit)
+    if (!globalPlayers)
     {
-        globalPlayers    = heap_caps_calloc(NUM_GLOBAL_PLAYERS, sizeof(midiPlayer_t), MALLOC_CAP_8BIT);
-        globalPlayerInit = true;
+        globalPlayers = heap_caps_calloc(NUM_GLOBAL_PLAYERS, sizeof(midiPlayer_t), MALLOC_CAP_8BIT);
         for (int i = 0; i < NUM_GLOBAL_PLAYERS; i++)
         {
             midiPlayerInit(&globalPlayers[i]);
@@ -2409,7 +2407,7 @@ void initGlobalMidiPlayer(void)
 
 void deinitGlobalMidiPlayer(void)
 {
-    if (globalPlayerInit)
+    if (globalPlayers)
     {
         for (int i = 0; i < NUM_GLOBAL_PLAYERS; i++)
         {
@@ -2418,14 +2416,14 @@ void deinitGlobalMidiPlayer(void)
             midiPlayerReset(&globalPlayers[i]);
         }
 
-        globalPlayerInit = false;
         free(globalPlayers);
+        globalPlayers = NULL;
     }
 }
 
 void globalMidiPlayerFillBuffer(uint8_t* samples, int16_t len)
 {
-    if (globalPlayerInit)
+    if (globalPlayers)
     {
         midiPlayerFillBufferMulti(globalPlayers, NUM_GLOBAL_PLAYERS, samples, len);
     }
@@ -2439,68 +2437,90 @@ void globalMidiPlayerPlaySong(midiFile_t* song, uint8_t songIdx)
 {
     initGlobalMidiPlayer();
 
-    midiPause(&globalPlayers[songIdx], true);
-    globalPlayers[songIdx].sampleCount = 0;
-    midiSetFile(&globalPlayers[songIdx], song);
-    midiPause(&globalPlayers[songIdx], false);
+    if (globalPlayers)
+    {
+        midiPause(&globalPlayers[songIdx], true);
+        globalPlayers[songIdx].sampleCount = 0;
+        midiSetFile(&globalPlayers[songIdx], song);
+        midiPause(&globalPlayers[songIdx], false);
+    }
 }
 
 void globalMidiPlayerPlaySongCb(midiFile_t* song, uint8_t songIdx, songFinishedCbFn cb)
 {
-    globalMidiPlayerPlaySong(song, songIdx);
-    globalPlayers[songIdx].songFinishedCallback = cb;
+    if (globalPlayers)
+    {
+        globalMidiPlayerPlaySong(song, songIdx);
+        globalPlayers[songIdx].songFinishedCallback = cb;
+    }
 }
 
 void globalMidiPlayerSetVolume(uint8_t trackType, int32_t volumeSetting)
 {
-    midiPlayer_t* player = &globalPlayers[trackType];
+    if (globalPlayers)
+    {
+        midiPlayer_t* player = &globalPlayers[trackType];
 
-    if (volumeSetting <= 0)
-    {
-        player->volume = 0;
-    }
-    else if (volumeSetting >= 13)
-    {
-        player->volume = UINT14_MAX;
-    }
-    else
-    {
-        player->volume = (1 << (volumeSetting - 1));
+        if (volumeSetting <= 0)
+        {
+            player->volume = 0;
+        }
+        else if (volumeSetting >= 13)
+        {
+            player->volume = UINT14_MAX;
+        }
+        else
+        {
+            player->volume = (1 << (volumeSetting - 1));
+        }
     }
 }
 
 void globalMidiPlayerPauseAll(void)
 {
-    for (int i = 0; i < NUM_GLOBAL_PLAYERS; i++)
+    if (globalPlayers)
     {
-        midiPause(&globalPlayers[i], true);
+        for (int i = 0; i < NUM_GLOBAL_PLAYERS; i++)
+        {
+            midiPause(&globalPlayers[i], true);
+        }
     }
 }
 
 void globalMidiPlayerResumeAll(void)
 {
-    for (int i = 0; i < NUM_GLOBAL_PLAYERS; i++)
+    if (globalPlayers)
     {
-        midiPause(&globalPlayers[i], false);
+        for (int i = 0; i < NUM_GLOBAL_PLAYERS; i++)
+        {
+            midiPause(&globalPlayers[i], false);
+        }
     }
 }
 
 void globalMidiPlayerStop(bool reset)
 {
-    for (int i = 0; i < NUM_GLOBAL_PLAYERS; i++)
+    if (globalPlayers)
     {
-        midiPause(&globalPlayers[i], true);
-
-        if (reset)
+        for (int i = 0; i < NUM_GLOBAL_PLAYERS; i++)
         {
-            midiPlayerReset(&globalPlayers[i]);
+            midiPause(&globalPlayers[i], true);
+
+            if (reset)
+            {
+                midiPlayerReset(&globalPlayers[i]);
+            }
+            // TODO: implement seek
+            // midiSeek(&globalPlayers[i], 0);
         }
-        // TODO: implement seek
-        // midiSeek(&globalPlayers[i], 0);
     }
 }
 
 midiPlayer_t* globalMidiPlayerGet(uint8_t songIdx)
 {
-    return &globalPlayers[songIdx];
+    if (globalPlayers)
+    {
+        return &globalPlayers[songIdx];
+    }
+    return NULL;
 }

--- a/main/modes/games/cGrove/mode_cGrove.c
+++ b/main/modes/games/cGrove/mode_cGrove.c
@@ -36,7 +36,7 @@ static const char cGroveTitle[] = "Chowa Grove"; // Game title
 static const char* cGroveMenuNames[]   = {"Play with Chowa", "Spar", "Race", "Perform", "Player Profiles", "Settings"};
 static const char* cGroveSettingOpts[] = {"Grove Touch Scroll: ", "Online: "};
 static const char* const cGroveEnabledOptions[] = {"Enabled", "Disabled"};
-static const int32_t cGroveEnabledVals[]       = {true, false};
+static const int32_t cGroveEnabledVals[]        = {true, false};
 
 static const char* cGroveTitleSprites[] = {"cg_cloud.wsg",          "cg_sky.wsg",
                                            "cg_title_1.wsg",        "cg_title_2.wsg",

--- a/main/modes/games/swadgeHero/mode_swadgeHero.c
+++ b/main/modes/games/swadgeHero/mode_swadgeHero.c
@@ -65,9 +65,6 @@ shVars_t* getShVars(void)
  */
 static void shEnterMode(void)
 {
-    // 60FPS please
-    setFrameRateUs(16667);
-
     // Allocate mode memory
     shv = calloc(1, sizeof(shVars_t));
 

--- a/main/modes/music/sequencer/sequencerMode.c
+++ b/main/modes/music/sequencer/sequencerMode.c
@@ -131,9 +131,6 @@ static sequencerVars_t* sv;
  */
 static void sequencerEnterMode(void)
 {
-    // Make it 60fps
-    setFrameRateUs(16667);
-
     // Allocate memory for the mode
     sv = calloc(1, sizeof(sequencerVars_t));
 

--- a/main/modes/music/tunernome/tunernome.c
+++ b/main/modes/music/tunernome/tunernome.c
@@ -40,7 +40,7 @@
 #define NUM_UKULELE_STRINGS          ARRAY_SIZE(ukuleleNoteNames)
 #define NUM_BANJO_STRINGS            ARRAY_SIZE(banjoNoteNames)
 #define GUITAR_OFFSET                0
-#define CHROMATIC_OFFSET             6 // adjust start point by quartertones
+#define CHROMATIC_OFFSET             6 // adjust start point by quarter tones
 #define SENSITIVITY                  5
 #define TONAL_DIFF_IN_TUNE_DEVIATION 10
 
@@ -54,7 +54,6 @@
 #define INITIAL_BPM          120
 #define MAX_BPM              400
 #define MAX_BEATS            16 // I mean, realistically, who's going to have more than 16 beats in a measure?
-#define METRONOME_FLASH_MS   35
 // #define METRONOME_CLICK_MS   35
 #define BPM_CHANGE_FIRST_MS  500
 #define BPM_CHANGE_FAST_MS   2000
@@ -119,6 +118,9 @@ typedef struct
     int32_t usPerBeat;
     uint8_t beatLength;
 
+    int32_t clickTimerUs;
+    uint8_t midiNote;
+
     uint32_t semitone_intensity_filt[NUM_SEMITONES];
     int32_t semitone_diff_filt[NUM_SEMITONES];
     int16_t tonalDiff[NUM_SEMITONES];
@@ -128,9 +130,7 @@ typedef struct
     wsg_t logbookArrowWsg;
     wsg_t flatWsg;
 
-    uint32_t blinkStartUs;
-    uint32_t blinkAccumulatedUs;
-    bool isBlinking;
+    int32_t blinkTimerUs;
     bool isSilent;
     bool isTouched;
 } tunernome_t;
@@ -237,15 +237,11 @@ const uint16_t freqBinIdxsBanjo[] = {
     58  // D
 };
 
-const uint16_t fourNoteStringIdxToLedIdx[] = {2, 3, 4, 5};
+const uint16_t fourNoteStringIdxToLedIdx[] = {1, 3, 5, 8};
 
-const uint16_t fiveNoteStringIdxToLedIdx[] = {0, 2, 3, 4, 5};
+const uint16_t fiveNoteStringIdxToLedIdx[] = {1, 2, 3, 5, 8};
 
-const uint16_t sixNoteStringIdxToLedIdx[] = {0, 2, 3, 4, 5, 7};
-
-const uint16_t twoLedFlashIdxs[] = {0, 7};
-
-const uint16_t fourLedFlashIdxs[] = {1, 3, 4, 6};
+const uint16_t sixNoteStringIdxToLedIdx[] = {0, 1, 3, 4, 5, 8};
 
 const char* const guitarNoteNames[] = {"E2", "A2", "D3", "G3", "B3", "E4"};
 
@@ -339,10 +335,9 @@ void tunernomeEnterMode(void)
 
     InitColorChord(&tunernome->end, &tunernome->dd);
 
-    tunernome->blinkStartUs       = 0;
-    tunernome->blinkAccumulatedUs = 0;
-    tunernome->isBlinking         = false;
-    tunernome->isSilent           = false;
+    tunernome->blinkTimerUs = 0;
+    tunernome->clickTimerUs = 0;
+    tunernome->isSilent     = false;
 }
 
 /**
@@ -354,9 +349,10 @@ void switchToSubmode(tnMode newMode)
     {
         case TN_TUNER:
         {
-            tunernome->mode = newMode;
+            // Disable speaker, enable mic
+            switchToMicrophone();
 
-            soundStop(true);
+            tunernome->mode = newMode;
 
             led_t leds[CONFIG_NUM_LEDS] = {{0}};
             setLeds(leds, CONFIG_NUM_LEDS);
@@ -367,11 +363,21 @@ void switchToSubmode(tnMode newMode)
         }
         case TN_METRONOME:
         {
+            // Disable mic, enable speaker
+            switchToSpeaker();
+
+            // Configure MIDI for streaming
+            midiPlayer_t* player      = globalMidiPlayerGet(MIDI_BGM);
+            player->mode              = MIDI_STREAMING;
+            player->streamingCallback = NULL;
+            midiGmOn(player);
+            midiPause(player, false);
+
             tunernome->mode = newMode;
 
             tunernome->isClockwise = true;
-            tunernome->beatCtr
-                = tunernome->beatLength - 1; // This assures that the first beat is a primary beat/downbeat
+            // This assures that the first beat is a primary beat/downbeat
+            tunernome->beatCtr        = tunernome->beatLength - 1;
             tunernome->tAccumulatedUs = 0;
 
             tunernome->lastBpmButton          = 0;
@@ -379,9 +385,8 @@ void switchToSubmode(tnMode newMode)
             tunernome->bpmButtonStartUs       = 0;
             tunernome->bpmButtonAccumulatedUs = 0;
 
-            tunernome->blinkStartUs       = 0;
-            tunernome->blinkAccumulatedUs = 0;
-            tunernome->isBlinking         = false;
+            tunernome->blinkTimerUs = 0;
+            tunernome->clickTimerUs = 0;
 
             recalcMetronome();
 
@@ -904,18 +909,10 @@ void tunernomeMainLoop(int64_t elapsedUs)
                      TFT_HEIGHT - tunernome->ibm_vga8.height - CORNER_OFFSET);
 
             // Other logic things
-            if (tunernome->isBlinking)
+            if (tunernome->blinkTimerUs > 0)
             {
-                if (tunernome->blinkAccumulatedUs == 0)
-                {
-                    tunernome->blinkAccumulatedUs = esp_timer_get_time() - tunernome->blinkStartUs;
-                }
-                else
-                {
-                    tunernome->blinkAccumulatedUs += elapsedUs;
-                }
-
-                if (tunernome->blinkAccumulatedUs > METRONOME_FLASH_MS * 1000)
+                tunernome->blinkTimerUs -= elapsedUs;
+                if (tunernome->blinkTimerUs <= 0)
                 {
                     led_t leds[CONFIG_NUM_LEDS] = {{0}};
                     setLeds(leds, CONFIG_NUM_LEDS);
@@ -933,13 +930,13 @@ void tunernomeMainLoop(int64_t elapsedUs)
                 {
                     // Flip the metronome arm
                     tunernome->isClockwise = false;
-                    // Start counting down by subtacting the excess time from tAccumulatedUs
+                    // Start counting down by subtracting the excess time from tAccumulatedUs
                     tunernome->tAccumulatedUs
                         = tunernome->usPerBeat - (tunernome->tAccumulatedUs - tunernome->usPerBeat);
                     // Blink LED Tick color
                     shouldBlink = true;
-                } // if(tAccumulatedUs >= tunernome->usPerBeat)
-            }     // if(tunernome->isClockwise)
+                }
+            }
             else
             {
                 // Subtract from tAccumulatedUs
@@ -953,20 +950,32 @@ void tunernomeMainLoop(int64_t elapsedUs)
                     tunernome->tAccumulatedUs = -(tunernome->tAccumulatedUs);
                     // Blink LED Tock color
                     shouldBlink = true;
-                } // if(tunernome->tAccumulatedUs <= 0)
-            }     // if(!tunernome->isClockwise)
+                }
+            }
+
+            // Count down a timer to turn the click off
+            if (!tunernome->isSilent)
+            {
+                if (tunernome->clickTimerUs > 0)
+                {
+                    tunernome->clickTimerUs -= elapsedUs;
+                    if (tunernome->clickTimerUs <= 0)
+                    {
+                        midiNoteOff(globalMidiPlayerGet(MIDI_BGM), 0, tunernome->midiNote, 0x7F);
+                    }
+                }
+            }
 
             if (shouldBlink)
             {
                 // Add one to the beat counter
                 tunernome->beatCtr = (tunernome->beatCtr + 1) % tunernome->beatLength;
 
-                // const song_t* song;
                 led_t leds[CONFIG_NUM_LEDS] = {{0}};
 
                 if (0 == tunernome->beatCtr)
                 {
-                    // song = &metronome_primary;
+                    tunernome->midiNote = 60; // C4
                     for (int i = 0; i < CONFIG_NUM_LEDS; i++)
                     {
                         leds[i].r = 0x40;
@@ -976,23 +985,25 @@ void tunernomeMainLoop(int64_t elapsedUs)
                 }
                 else
                 {
-                    // song = &metronome_secondary;
-                    for (int i = 0; i < 4; i++)
+                    const uint8_t offBeatLeds[] = {1, 3, 5, 8};
+                    tunernome->midiNote         = 69; // A4
+                    for (int i = 0; i < ARRAY_SIZE(offBeatLeds); i++)
                     {
-                        leds[fourLedFlashIdxs[i]].r = 0x40;
-                        leds[fourLedFlashIdxs[i]].g = 0x00;
-                        leds[fourLedFlashIdxs[i]].b = 0xFF;
+                        leds[offBeatLeds[i]].r = 0x40;
+                        leds[offBeatLeds[i]].g = 0x00;
+                        leds[offBeatLeds[i]].b = 0xFF;
                     }
                 }
 
-                /*if (!tunernome->isSilent)
+                if (!tunernome->isSilent)
                 {
-                    soundPlaySfx(song, BZR_STEREO);
-                }*/
+                    // Click  here
+                    midiNoteOn(globalMidiPlayerGet(MIDI_BGM), 0, tunernome->midiNote, 0x7F);
+                    tunernome->clickTimerUs = DEFAULT_FRAME_RATE_US * 3;
+                }
+
                 setLeds(leds, CONFIG_NUM_LEDS);
-                tunernome->isBlinking         = true;
-                tunernome->blinkStartUs       = esp_timer_get_time();
-                tunernome->blinkAccumulatedUs = 0;
+                tunernome->blinkTimerUs = DEFAULT_FRAME_RATE_US * 3;
             }
 
             // Runs after the up or down button is held long enough in metronome mode.
@@ -1055,8 +1066,8 @@ void tunernomeMainLoop(int64_t elapsedUs)
             int y           = round(METRONOME_CENTER_Y - (ABS(intermedY) * METRONOME_RADIUS));
             drawLine(METRONOME_CENTER_X, METRONOME_CENTER_Y, x, y, c555, 0);
             break;
-        } // case TN_METRONOME:
-    }     // switch(tunernome->mode)
+        }
+    }
 }
 
 /**
@@ -1117,10 +1128,10 @@ void tunernomeProcessButtons(buttonEvt_t* evt)
                     {
                         break;
                     }
-                } // switch(button)
-            }     // if(down)
+                }
+            }
             break;
-        } // case TN_TUNER:
+        }
         case TN_METRONOME:
         {
             if (evt->down)
@@ -1173,8 +1184,8 @@ void tunernomeProcessButtons(buttonEvt_t* evt)
                     {
                         break;
                     }
-                } // switch(button)
-            }     // if(down)
+                }
+            }
             else
             {
                 // Stop button repetition and reset related variables
@@ -1205,7 +1216,7 @@ void tunernomeProcessButtons(buttonEvt_t* evt)
                 }
             }
             break;
-        } // case TN_METRONOME:
+        }
     }
 }
 
@@ -1309,64 +1320,68 @@ void tunernomeSampleHandler(uint16_t* samples, uint32_t sampleCnt)
                                                          / (tunernome->intensity[semitone] + 1);
                     }
 
-                    // tonal diff is -32768 to 32767. if its within -10 to 10 (now defined as
-                    // TONAL_DIFF_IN_TUNE_DEVIATION), it's in tune. positive means too sharp, negative means too flat
-                    // intensity is how 'loud' that frequency is, 0 to 255. you'll have to play around with values
-                    int32_t red, grn, blu;
-                    // Is the note in tune, i.e. is the magnitude difference in surrounding bins small?
-                    if ((ABS(tunernome->tonalDiff[tunernome->curTunerMode - SEMITONE_0])
-                         < TONAL_DIFF_IN_TUNE_DEVIATION))
+                    if (tunernome->curTunerMode < LISTENING)
                     {
-                        // Note is in tune, make it white
-                        red = 255;
-                        grn = 255;
-                        blu = 255;
-                    }
-                    else
-                    {
-                        // Check if the note is sharp or flat
-                        if (tunernome->tonalDiff[tunernome->curTunerMode - SEMITONE_0] > 0)
+                        // tonal diff is -32768 to 32767. if its within -10 to 10 (now defined as
+                        // TONAL_DIFF_IN_TUNE_DEVIATION), it's in tune. positive means too sharp, negative means too
+                        // flat intensity is how 'loud' that frequency is, 0 to 255. you'll have to play around with
+                        // values
+                        int32_t red, grn, blu;
+                        // Is the note in tune, i.e. is the magnitude difference in surrounding bins small?
+                        if ((ABS(tunernome->tonalDiff[tunernome->curTunerMode - SEMITONE_0])
+                             < TONAL_DIFF_IN_TUNE_DEVIATION))
                         {
-                            // Note too sharp, make it red
+                            // Note is in tune, make it white
                             red = 255;
-                            grn = blu = 255
-                                        - (tunernome->tonalDiff[tunernome->curTunerMode - SEMITONE_0]
-                                           - TONAL_DIFF_IN_TUNE_DEVIATION)
-                                              * 15;
+                            grn = 255;
+                            blu = 255;
                         }
                         else
                         {
-                            // Note too flat, make it blue
-                            blu = 255;
-                            grn = red = 255
-                                        - (-(tunernome->tonalDiff[tunernome->curTunerMode - SEMITONE_0]
-                                             + TONAL_DIFF_IN_TUNE_DEVIATION))
-                                              * 15;
+                            // Check if the note is sharp or flat
+                            if (tunernome->tonalDiff[tunernome->curTunerMode - SEMITONE_0] > 0)
+                            {
+                                // Note too sharp, make it red
+                                red = 255;
+                                grn = blu = 255
+                                            - (tunernome->tonalDiff[tunernome->curTunerMode - SEMITONE_0]
+                                               - TONAL_DIFF_IN_TUNE_DEVIATION)
+                                                  * 15;
+                            }
+                            else
+                            {
+                                // Note too flat, make it blue
+                                blu = 255;
+                                grn = red = 255
+                                            - (-(tunernome->tonalDiff[tunernome->curTunerMode - SEMITONE_0]
+                                                 + TONAL_DIFF_IN_TUNE_DEVIATION))
+                                                  * 15;
+                            }
+
+                            // Make sure LED output isn't more than 255
+                            red = CLAMP(red, INT_MIN, 255);
+                            grn = CLAMP(grn, INT_MIN, 255);
+                            blu = CLAMP(blu, INT_MIN, 255);
                         }
 
-                        // Make sure LED output isn't more than 255
-                        red = CLAMP(red, INT_MIN, 255);
-                        grn = CLAMP(grn, INT_MIN, 255);
-                        blu = CLAMP(blu, INT_MIN, 255);
-                    }
+                        // Scale each LED's brightness by the filtered intensity for that bin
+                        red = (red >> 3) * (tunernome->intensity[tunernome->curTunerMode - SEMITONE_0] >> 3);
+                        grn = (grn >> 3) * (tunernome->intensity[tunernome->curTunerMode - SEMITONE_0] >> 3);
+                        blu = (blu >> 3) * (tunernome->intensity[tunernome->curTunerMode - SEMITONE_0] >> 3);
 
-                    // Scale each LED's brightness by the filtered intensity for that bin
-                    red = (red >> 3) * (tunernome->intensity[tunernome->curTunerMode - SEMITONE_0] >> 3);
-                    grn = (grn >> 3) * (tunernome->intensity[tunernome->curTunerMode - SEMITONE_0] >> 3);
-                    blu = (blu >> 3) * (tunernome->intensity[tunernome->curTunerMode - SEMITONE_0] >> 3);
-
-                    // Set the LED, ensure each channel is between 0 and 255
-                    uint32_t i;
-                    for (i = 0; i < NUM_GUITAR_STRINGS; i++)
-                    {
-                        colors[i].r = CLAMP(red, 0, 255);
-                        colors[i].g = CLAMP(grn, 0, 255);
-                        colors[i].b = CLAMP(blu, 0, 255);
+                        // Set the LED, ensure each channel is between 0 and 255
+                        uint32_t i;
+                        for (i = 0; i < CONFIG_NUM_LEDS; i++)
+                        {
+                            colors[i].r = CLAMP(red, 0, 255);
+                            colors[i].g = CLAMP(grn, 0, 255);
+                            colors[i].b = CLAMP(blu, 0, 255);
+                        }
                     }
 
                     break;
-                } // default:
-            }     // switch(tunernome->curTunerMode)
+                }
+            }
 
             if (LISTENING != tunernome->curTunerMode)
             {
@@ -1376,5 +1391,5 @@ void tunernomeSampleHandler(uint16_t* samples, uint32_t sampleCnt)
             // Reset the sample count
             tunernome->audioSamplesProcessed = 0;
         }
-    } // if(tunernome-> mode == TN_TUNER)
+    }
 }

--- a/main/modes/utilities/gamepad/gamepad.c
+++ b/main/modes/utilities/gamepad/gamepad.c
@@ -294,9 +294,6 @@ void gamepadEnterMode(void)
     // Initialize menu renderer
     gamepad->renderer = initMenuManiaRenderer(NULL, NULL, NULL);
 
-    // We shold go as fast as we can
-    setFrameRateUs(0);
-
     // Set up the IMU
     accelSetRegistersAndReset();
 }

--- a/main/modes/utilities/timer/modeTimer.c
+++ b/main/modes/utilities/timer/modeTimer.c
@@ -131,9 +131,6 @@ static void timerEnterMode(void)
     loadWsg("button_a.wsg", &timerData->aWsg, false);
     loadWsg("button_b.wsg", &timerData->bWsg, false);
 
-    // 100FPS? Sure?
-    setFrameRateUs(1000000 / 100);
-
     // Default to 30s
     timerData->countdownTime = 30 * 1000000;
     timerData->timerState    = STOPPED;

--- a/main/swadge2024.c
+++ b/main/swadge2024.c
@@ -824,3 +824,41 @@ void dacCallback(uint8_t* samples, int16_t len)
         globalMidiPlayerFillBuffer(samples, len);
     }
 }
+
+/**
+ * @brief Enable the speaker (and battery monitor) and disable the microphone
+ */
+void switchToSpeaker(void)
+{
+    // Stop the microphone
+    stopMic();
+    deinitMic();
+
+    // Start the speaker
+    initDac(DAC_CHANNEL_MASK_CH0, // GPIO_NUM_17
+            GPIO_NUM_18, dacCallback);
+    setDacShutdown(false);
+    initGlobalMidiPlayer();
+
+    // Start battery monitoring
+    initBattmon(GPIO_NUM_6);
+}
+
+/**
+ * @brief Enable the microphone and disable the speaker (and battery monitor)
+ */
+void switchToMicrophone(void)
+{
+    // Stop battery monitoring
+    deinitBattmon();
+
+    // Stop the speaker
+    globalMidiPlayerStop(true);
+    deinitGlobalMidiPlayer();
+    setDacShutdown(true);
+    deinitDac();
+
+    // Initialize and start the mic as a continuous ADC
+    initMic(GPIO_NUM_7);
+    startMic();
+}

--- a/main/swadge2024.h
+++ b/main/swadge2024.h
@@ -356,4 +356,7 @@ void openQuickSettings(void);
 void setFrameRateUs(uint32_t newFrameRateUs);
 uint32_t getFrameRateUs(void);
 
+void switchToSpeaker(void);
+void switchToMicrophone(void);
+
 #endif


### PR DESCRIPTION
### Description

Added ability to switch between DAC and ADC modes.
Got Tunernome clicking again.
Dial back framerates to 40fps a few places

### Test Instructions

Try different instrument tuners.
Try different metronome tempos and signatures.
Pull up the quick settings menu in both modes.

### Ticket Links

#281

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
