### PR TITLE
Use the player's marker for 2p local system

### DIFF
--- a/main/modes/games/ultimateTTT/ultimateTTT.c
+++ b/main/modes/games/ultimateTTT/ultimateTTT.c
@@ -52,6 +52,12 @@ const char tttMarkerKey[]   = "ttt_marker";
 const char tttTutorialKey[] = "ttt_tutor";
 const char tttUnlockKey[]   = "ttt_unlock";
 
+static const led_t utttLedMenuColor = {
+    .r = 0xFF,
+    .g = 0x99,
+    .b = 0xCC,
+};
+
 /**
  * Marker names to load WSGs
  */
@@ -122,18 +128,13 @@ static void tttEnterMode(void)
     // Initialize a menu renderer
     ttt->menuRenderer = initMenuManiaRenderer(&ttt->font_righteous, NULL, &ttt->font_rodin);
     // Color the menu like Poe
-    led_t menuColor = {
-        .r = 0xFF,
-        .g = 0x00,
-        .b = 0x00,
-    };
     static const paletteColor_t shadowColors[] = {c500, c511, c522, c533, c544, c555, c544, c533, c522, c511};
     recolorMenuManiaRenderer(ttt->menuRenderer, //
                              c500, c555, c111,  // titleBgColor, titleTextColor, textOutlineColor
                              c333,              // bgColor
                              c534, c544,        // outerRingColor, innerRingColor
                              c212, c555,        // rowColor, rowTextColor
-                             shadowColors, ARRAY_SIZE(shadowColors), menuColor);
+                             shadowColors, ARRAY_SIZE(shadowColors), utttLedMenuColor);
 
     // Initialize the main menu
     ttt->menu = initMenu(tttName, tttMenuCb);
@@ -488,6 +489,7 @@ void tttShowUi(tttUi_t ui)
 
     // Assume menu LEDs should be on
     setManiaLedsOn(ttt->menuRenderer, true);
+    ttt->menuRenderer->baseLedColor = utttLedMenuColor;
 
     // Initialize the new UI
     switch (ttt->ui)

--- a/main/modes/games/ultimateTTT/ultimateTTTgame.c
+++ b/main/modes/games/ultimateTTT/ultimateTTTgame.c
@@ -145,6 +145,9 @@ void tttBeginGame(ultimateTTT_t* ttt)
             ttt->game.cpu.state = TCPU_THINKING;
         }
 
+        // Set own marker type
+        ttt->game.p2MarkerIdx = ttt->activeMarkerIdx;
+
         // Randomize markers to be not match
         ttt->game.p1MarkerIdx = esp_random() % ttt->numUnlockedMarkers;
         // While the markers match
@@ -882,7 +885,16 @@ static playOrder_t tttGetPlayOrder(ultimateTTT_t* ttt)
  */
 void tttDrawGame(ultimateTTT_t* ttt)
 {
+    // LED setting for wireless & pass and play
     bool isP1 = (GOING_FIRST == tttGetPlayOrder(ttt));
+
+    // Override for CPU matches during the CPU's turn
+    if ((true == ttt->game.singleSystem) && //
+        (false == ttt->game.passAndPlay) && //
+        (ttt->game.state == TGS_WAITING))
+    {
+        isP1 = !isP1;
+    }
 
     // Light LEDs for p1/p2
     led_t leds[CONFIG_NUM_LEDS] = {0};

--- a/main/modes/games/ultimateTTT/ultimateTTTresult.c
+++ b/main/modes/games/ultimateTTT/ultimateTTTresult.c
@@ -66,11 +66,17 @@ void tttDrawResult(ultimateTTT_t* ttt, int64_t elapsedUs)
             {
                 if (GOING_FIRST == ttt->game.singlePlayerPlayOrder)
                 {
-                    resultStr = redStr;
+                    resultStr                         = redStr;
+                    ttt->menuRenderer->baseLedColor.r = 0xFF;
+                    ttt->menuRenderer->baseLedColor.g = 0x00;
+                    ttt->menuRenderer->baseLedColor.b = 0x00;
                 }
                 else
                 {
-                    resultStr = blueStr;
+                    resultStr                         = blueStr;
+                    ttt->menuRenderer->baseLedColor.r = 0x00;
+                    ttt->menuRenderer->baseLedColor.g = 0x00;
+                    ttt->menuRenderer->baseLedColor.b = 0xFF;
                 }
             }
             else


### PR DESCRIPTION
### Description

Fix LEDs for CPU moves, result screen

### Test Instructions

Play a bunch of single system UTTT games and make sure you always have your selected marker

Make sure LED color matches the player during CPU matches and on the result screen.

### Ticket Links

n/a

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
