### PR TITLE
Fix rotation

### DIFF
--- a/main/display/wsg.c
+++ b/main/display/wsg.c
@@ -24,7 +24,7 @@
  * @param width  The width of the image
  * @param height The height of the image
  */
-void rotatePixel(int16_t* x, int16_t* y, int16_t rotateDeg, int16_t width, int16_t height)
+void rotatePixel(int32_t* x, int32_t* y, int32_t rotateDeg, int32_t width, int32_t height)
 {
     //  This function has been micro optimized by cnlohr on 2022-09-07, using gcc version 8.4.0 (crosstool-NG
     //  esp-2021r2-patch3)
@@ -50,7 +50,7 @@ void rotatePixel(int16_t* x, int16_t* y, int16_t rotateDeg, int16_t width, int16
     if (rotateDeg >= 270)
     {
         // (x, y) -> (y, -x)
-        int16_t tmp = wx;
+        int32_t tmp = wx;
         wx          = wy;
         wy          = 2 * tx - tmp + width - 1;
         rotateDeg -= 270;
@@ -65,7 +65,7 @@ void rotatePixel(int16_t* x, int16_t* y, int16_t rotateDeg, int16_t width, int16
     else if (rotateDeg >= 90)
     {
         // (x, y) -> (-y, x)
-        int16_t tmp = wx;
+        int32_t tmp = wx;
         wx          = 2 * ty - wy + height - 1;
         wy          = tmp;
         rotateDeg -= 90;
@@ -102,7 +102,7 @@ void rotatePixel(int16_t* x, int16_t* y, int16_t rotateDeg, int16_t width, int16
  * @param flipUD true to flip the image across the X axis
  * @param rotateDeg The number of degrees to rotate clockwise, must be 0-359
  */
-void drawWsg(const wsg_t* wsg, int16_t xOff, int16_t yOff, bool flipLR, bool flipUD, int16_t rotateDeg)
+void drawWsg(const wsg_t* wsg, int32_t xOff, int32_t yOff, bool flipLR, bool flipUD, int32_t rotateDeg)
 {
     //  This function has been micro optimized by cnlohr on 2022-09-08, using gcc version 8.4.0 (crosstool-NG
     //  esp-2021r2-patch3)
@@ -125,8 +125,8 @@ void drawWsg(const wsg_t* wsg, int16_t xOff, int16_t yOff, bool flipLR, bool fli
     if (rotateDeg)
     {
         SETUP_FOR_TURBO();
-        uint32_t wsgw = wsg->w;
-        uint32_t wsgh = wsg->h;
+        int32_t wsgw = wsg->w;
+        int32_t wsgh = wsg->h;
         for (int32_t srcY = 0; srcY < wsgh; srcY++)
         {
             int32_t usey = srcY;
@@ -140,30 +140,29 @@ void drawWsg(const wsg_t* wsg, int16_t xOff, int16_t yOff, bool flipLR, bool fli
             const paletteColor_t* linein = &wsg->px[usey * wsgw];
 
             // Reflect over Y axis?
-            uint32_t readX    = 0;
-            uint32_t advanceX = 1;
+            int32_t readX    = 0;
+            int32_t advanceX = 1;
             if (flipLR)
             {
                 readX    = wsgw - 1;
                 advanceX = -1;
             }
 
-            int32_t localX = 0;
             for (int32_t srcX = 0; srcX != wsgw; srcX++)
             {
                 // Draw if not transparent
-                uint8_t color = linein[readX];
+                paletteColor_t color = linein[readX];
                 if (cTransparent != color)
                 {
-                    uint16_t tx = localX;
-                    uint16_t ty = srcY;
+                    int32_t tx = srcX;
+                    int32_t ty = srcY;
 
-                    rotatePixel((int16_t*)&tx, (int16_t*)&ty, rotateDeg, wsgw, wsgh);
+                    rotatePixel(&tx, &ty, rotateDeg, wsgw, wsgh);
+
                     tx += xOff;
                     ty += yOff;
                     TURBO_SET_PIXEL_BOUNDS(tx, ty, color);
                 }
-                localX++;
                 readX += advanceX;
             }
         }

--- a/main/display/wsg.h
+++ b/main/display/wsg.h
@@ -60,8 +60,8 @@ typedef struct
     uint16_t h;         ///< The height of the image
 } wsg_t;
 
-void rotatePixel(int16_t* x, int16_t* y, int16_t rotateDeg, int16_t width, int16_t height);
-void drawWsg(const wsg_t* wsg, int16_t xOff, int16_t yOff, bool flipLR, bool flipUD, int16_t rotateDeg);
+void rotatePixel(int32_t* x, int32_t* y, int32_t rotateDeg, int32_t width, int32_t height);
+void drawWsg(const wsg_t* wsg, int32_t xOff, int32_t yOff, bool flipLR, bool flipUD, int32_t rotateDeg);
 void drawWsgSimple(const wsg_t* wsg, int16_t xOff, int16_t yOff);
 void drawWsgSimpleScaled(const wsg_t* wsg, int16_t xOff, int16_t yOff, int16_t xScale, int16_t yScale);
 void drawWsgTile(const wsg_t* wsg, int32_t xOff, int32_t yOff);

--- a/main/display/wsgPalette.c
+++ b/main/display/wsgPalette.c
@@ -34,8 +34,8 @@
  * @param flipUD true to flip the image across the X axis
  * @param rotateDeg The number of degrees to rotate clockwise, must be 0-359
  */
-void drawWsgPalette(const wsg_t* wsg, int16_t xOff, int16_t yOff, wsgPalette_t* palette, bool flipLR, bool flipUD,
-                    int16_t rotateDeg)
+void drawWsgPalette(const wsg_t* wsg, int32_t xOff, int32_t yOff, wsgPalette_t* palette, bool flipLR, bool flipUD,
+                    int32_t rotateDeg)
 {
     //  This function has been micro optimized by cnlohr on 2022-09-08, using gcc version 8.4.0 (crosstool-NG
     //  esp-2021r2-patch3)
@@ -48,8 +48,8 @@ void drawWsgPalette(const wsg_t* wsg, int16_t xOff, int16_t yOff, wsgPalette_t* 
     if (rotateDeg)
     {
         SETUP_FOR_TURBO();
-        uint32_t wsgw = wsg->w;
-        uint32_t wsgh = wsg->h;
+        int32_t wsgw = wsg->w;
+        int32_t wsgh = wsg->h;
         for (int32_t srcY = 0; srcY < wsgh; srcY++)
         {
             int32_t usey = srcY;
@@ -63,30 +63,29 @@ void drawWsgPalette(const wsg_t* wsg, int16_t xOff, int16_t yOff, wsgPalette_t* 
             const paletteColor_t* linein = &wsg->px[usey * wsgw];
 
             // Reflect over Y axis?
-            uint32_t readX    = 0;
-            uint32_t advanceX = 1;
+            int32_t readX    = 0;
+            int32_t advanceX = 1;
             if (flipLR)
             {
                 readX    = wsgw - 1;
                 advanceX = -1;
             }
 
-            int32_t localX = 0;
             for (int32_t srcX = 0; srcX != wsgw; srcX++)
             {
                 // Draw if not transparent
-                uint8_t color = palette->newColors[linein[readX]];
+                paletteColor_t color = palette->newColors[linein[readX]];
                 if (cTransparent != color)
                 {
-                    uint16_t tx = localX;
-                    uint16_t ty = srcY;
+                    int32_t tx = srcX;
+                    int32_t ty = srcY;
 
-                    rotatePixel((int16_t*)&tx, (int16_t*)&ty, rotateDeg, wsgw, wsgh);
+                    rotatePixel(&tx, &ty, rotateDeg, wsgw, wsgh);
+
                     tx += xOff;
                     ty += yOff;
                     TURBO_SET_PIXEL_BOUNDS(tx, ty, color);
                 }
-                localX++;
                 readX += advanceX;
             }
         }

--- a/main/display/wsgPalette.h
+++ b/main/display/wsgPalette.h
@@ -79,8 +79,8 @@ typedef struct
 // Functions
 //==============================================================================
 
-void drawWsgPalette(const wsg_t* wsg, int16_t xOff, int16_t yOff, wsgPalette_t* palette, bool flipLR, bool flipUD,
-                    int16_t rotateDeg);
+void drawWsgPalette(const wsg_t* wsg, int32_t xOff, int32_t yOff, wsgPalette_t* palette, bool flipLR, bool flipUD,
+                    int32_t rotateDeg);
 void drawWsgPaletteSimple(const wsg_t* wsg, int16_t xOff, int16_t yOff, wsgPalette_t* palette);
 void drawWsgPaletteSimpleScaled(const wsg_t* wsg, int16_t xOff, int16_t yOff, wsgPalette_t* palette, int16_t xScale,
                                 int16_t yScale);

--- a/main/modes/games/ultimateTTT/ultimateTTTgame.c
+++ b/main/modes/games/ultimateTTT/ultimateTTTgame.c
@@ -978,7 +978,7 @@ void tttDrawGame(ultimateTTT_t* ttt, uint32_t elapsedUs)
         for (int32_t x = 0; x < 3; x++)
         {
             // Check animation timers for the subgame winners
-            if (ttt->game.gameTimers[x][y] > 0)
+            if (ttt->game.gameTimers[x][y] > elapsedUs)
             {
                 ttt->game.gameTimers[x][y] -= elapsedUs;
             }
@@ -992,7 +992,7 @@ void tttDrawGame(ultimateTTT_t* ttt, uint32_t elapsedUs)
                 for (int32_t sx = 0; sx < 3; sx++)
                 {
                     // Check animation timers for the subgame cells
-                    if (ttt->game.cellTimers[x][y][sx][sy] > 0)
+                    if (ttt->game.cellTimers[x][y][sx][sy] > elapsedUs)
                     {
                         ttt->game.cellTimers[x][y][sx][sy] -= elapsedUs;
                     }
@@ -1022,7 +1022,7 @@ void tttDrawGame(ultimateTTT_t* ttt, uint32_t elapsedUs)
     tttDrawGrid(ttt->gameOffset.x, ttt->gameOffset.y, ttt->gameOffset.x + ttt->gameSize - 1,
                 ttt->gameOffset.y + ttt->gameSize - 1, 0, MAIN_GRID_COLOR);
 
-    // For each subgame
+    // Draw the background for each subgame
     for (int subY = 0; subY < 3; subY++)
     {
         for (int subX = 0; subX < 3; subX++)
@@ -1043,7 +1043,19 @@ void tttDrawGame(ultimateTTT_t* ttt, uint32_t elapsedUs)
 
             // Draw the subgame grid lines
             tttDrawGrid(sX0, sY0, sX1, sY1, 4, SUB_GRID_COLOR);
+        }
+    }
 
+    // Draw the markers for each subgame
+    for (int subY = 0; subY < 3; subY++)
+    {
+        for (int subX = 0; subX < 3; subX++)
+        {
+            // Get this subgame's rectangle
+            int16_t sX0 = ttt->gameOffset.x + (subX * ttt->subgameSize);
+            int16_t sY0 = ttt->gameOffset.y + (subY * ttt->subgameSize);
+            int16_t sX1 = sX0 + ttt->subgameSize - 1;
+            int16_t sY1 = sY0 + ttt->subgameSize - 1;
             // If selected, draw the cursor on this subgame
             if (SELECT_SUBGAME == ttt->game.cursorMode && //
                 ttt->game.cursor.x == subX && ttt->game.cursor.y == subY)


### PR DESCRIPTION
### Description

Fixed sprites clipping while rotated

### Test Instructions

Play UTTT, make sure sprites don't clip while rotating

### Ticket Links

#349 

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
