### PR TITLE
Fixed C stick controls fort Chowa

### DIFF
--- a/main/modes/games/cGrove/Garden/cg_Grove.c
+++ b/main/modes/games/cGrove/Garden/cg_Grove.c
@@ -881,14 +881,13 @@ static void cg_handleInputGarden(cGrove_t* cg)
         {
             if (getTouchJoystick(&phi, &r, &intensity))
             {
-                int16_t speed = phi >> 5;
-                if (!(speed <= 5))
+                if (r >= 500)
                 {
                     /* ESP_LOGI("CG", "touch center: %" PRIu32 ", intensity: %" PRIu32 ", intensity %" PRIu32, phi, r,
-                     * intensity); */
+                     intensity);  */
                     // Move hand
-                    cg->grove.cursor.pos.x += (getCos1024(phi) * speed) / 1024;
-                    cg->grove.cursor.pos.y -= (getSin1024(phi) * speed) / 1024;
+                    cg->grove.cursor.pos.x += (getCos1024(phi) * (r >> 5)) / 1024;
+                    cg->grove.cursor.pos.y -= (getSin1024(phi) * (r >> 5)) / 1024;
                 }
             }
             while (checkButtonQueueWrapper(&evt))


### PR DESCRIPTION
### Description

Fixed C-Stick in the Chowa "Grove" mode.

### Test Instructions

Ran emulator, Chowa grove, main grove mode with C stick controls enabled. Moves stick around in all directions.

### Ticket Links

None. Hotfix.

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
