### PR TITLE
Fix Chowa Name Race Condition

### DIFF
--- a/main/modes/games/cGrove/Garden/cg_GroveAI.c
+++ b/main/modes/games/cGrove/Garden/cg_GroveAI.c
@@ -419,6 +419,8 @@ void cg_GroveEggAI(cGrove_t* cg, int64_t elapsedUs)
                 strcpy(cg->chowa[idx].owner, cg->player);
                 cg->grove.state    = CG_KEYBOARD_WRITE_NAME;
                 cg->grove.hatchIdx = idx;
+                // break after hatching so future Chowa don't hatch first.
+                break;
             }
         }
     }


### PR DESCRIPTION
[Problem]
When multiple Chowa hatch in the same frame, only the first one to hatch is able to be named since the others won't trigger the state changes.

[Solution]
Ensure we stop processing Chowa states until after the names have been entered.

[Testing]
Confirmed working with 2 and 3 Chowa hatching at the same time.

### Description

Fixing issue #364 

### Test Instructions

Tested hatching multiple Chowa at the same time (2 and 3)

### Ticket Links

https://github.com/AEFeinstein/Super-2024-Swadge-FW/issues/364

### Readiness Checklist
- [X] I have run `make format` to format the changes
- [X] I have compiled the firmware and the changes have no warnings
- [X] I have compiled the emulator and the changes have no warnings
- [X] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [X] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [X] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
