### PR TITLE
Improve 2048 motion controls

### DIFF
--- a/main/modes/games/2048/2048_game.c
+++ b/main/modes/games/2048/2048_game.c
@@ -255,6 +255,19 @@ void t48_gameLoop(t48_t* t48, int32_t elapsedUs)
         // Accept input again
         t48->acceptGameInput = true;
     }
+
+
+    if (t48->tiltControls)
+    {
+        const int indicatorx = 190;
+        const int indicatory = 10;
+        const int indicatorSize = 9;
+        int dx = CLAMP(t48->lastIMUx >> 4, -indicatorSize, indicatorSize);
+        int dy =-CLAMP(t48->lastIMUy >> 4, -indicatorSize, indicatorSize);
+        drawRect(indicatorx - indicatorSize - 1, indicatory - indicatorSize - 1,
+                 indicatorx + indicatorSize + 1, indicatory + indicatorSize + 1, c333 );
+        drawCircle(indicatorx + dx, indicatory + dy, 1, c555 );
+    }
 }
 
 /**

--- a/main/modes/games/2048/2048_game.c
+++ b/main/modes/games/2048/2048_game.c
@@ -261,8 +261,8 @@ void t48_gameLoop(t48_t* t48, int32_t elapsedUs)
         const int indicatorx    = 190;
         const int indicatory    = 10;
         const int indicatorSize = 9;
-        int dx                  = CLAMP(t48->lastIMUx >> 4, -indicatorSize, indicatorSize);
-        int dy                  = -CLAMP(t48->lastIMUy >> 4, -indicatorSize, indicatorSize);
+        int dx                  = -CLAMP(t48->lastIMUx >> 4, -indicatorSize, indicatorSize);
+        int dy                  = CLAMP(t48->lastIMUy >> 4, -indicatorSize, indicatorSize);
         drawRect(indicatorx - indicatorSize, indicatory - indicatorSize, indicatorx + indicatorSize + 1,
                  indicatory + indicatorSize + 1, c333);
         drawCircle(indicatorx + dx, indicatory + dy, 1, c555);

--- a/main/modes/games/2048/2048_game.c
+++ b/main/modes/games/2048/2048_game.c
@@ -256,17 +256,16 @@ void t48_gameLoop(t48_t* t48, int32_t elapsedUs)
         t48->acceptGameInput = true;
     }
 
-
     if (t48->tiltControls)
     {
-        const int indicatorx = 190;
-        const int indicatory = 10;
+        const int indicatorx    = 190;
+        const int indicatory    = 10;
         const int indicatorSize = 9;
-        int dx = CLAMP(t48->lastIMUx >> 4, -indicatorSize, indicatorSize);
-        int dy =-CLAMP(t48->lastIMUy >> 4, -indicatorSize, indicatorSize);
-        drawRect(indicatorx - indicatorSize, indicatory - indicatorSize,
-                 indicatorx + indicatorSize + 1, indicatory + indicatorSize + 1, c333 );
-        drawCircle(indicatorx + dx, indicatory + dy, 1, c555 );
+        int dx                  = CLAMP(t48->lastIMUx >> 4, -indicatorSize, indicatorSize);
+        int dy                  = -CLAMP(t48->lastIMUy >> 4, -indicatorSize, indicatorSize);
+        drawRect(indicatorx - indicatorSize, indicatory - indicatorSize, indicatorx + indicatorSize + 1,
+                 indicatory + indicatorSize + 1, c333);
+        drawCircle(indicatorx + dx, indicatory + dy, 1, c555);
     }
 }
 

--- a/main/modes/games/2048/2048_game.c
+++ b/main/modes/games/2048/2048_game.c
@@ -264,7 +264,7 @@ void t48_gameLoop(t48_t* t48, int32_t elapsedUs)
         const int indicatorSize = 9;
         int dx = CLAMP(t48->lastIMUx >> 4, -indicatorSize, indicatorSize);
         int dy =-CLAMP(t48->lastIMUy >> 4, -indicatorSize, indicatorSize);
-        drawRect(indicatorx - indicatorSize - 1, indicatory - indicatorSize - 1,
+        drawRect(indicatorx - indicatorSize, indicatory - indicatorSize,
                  indicatorx + indicatorSize + 1, indicatory + indicatorSize + 1, c333 );
         drawCircle(indicatorx + dx, indicatory + dy, 1, c555 );
     }

--- a/main/modes/games/2048/mode_2048.c
+++ b/main/modes/games/2048/mode_2048.c
@@ -20,6 +20,8 @@
 #include "2048_menus.h"
 #include "textEntry.h"
 
+#include "advanced_usb_control.h"
+
 //==============================================================================
 // Function Prototypes
 //==============================================================================
@@ -232,31 +234,74 @@ static void t48MainLoop(int64_t elapsedUs)
             // Take accel input if cells aren't moving
             if (t48->tiltControls && !t48->cellsAnimating)
             {
-                int16_t ox, oy, oz;
-                if (ESP_OK == accelGetOrientVec(&ox, &oy, &oz))
+                //int16_t ox, oy, oz;
+                float q[4];
+                esp_err_t aq = accelGetQuaternion( q );
+                if (ESP_OK == aq)
                 {
-                    if (ABS(ox) > ABS(oy))
+                    float qRelativeRotation[4];
+
+                    // this takes about 36 flops.
+                    mathComputeQuaternionDeltaBetweenQuaternions( qRelativeRotation, t48->quatBase, q);
+
+                    // qRelativeRotation represents the rotation from the initial state to now. 
+                    // The quaternion is:  [w, x, y, z]
+                    //  the w term, more like the part that sums everything to a unit quaternion.
+                    //  the x term is the amount of rotation around the x axis.
+                    //  the y term is the amount of rotation around the y axis.
+                    //  the z term is the amount of rotation around the z axis.
+                    // Not quite like euler angles, but kinda?
+                    //
+                    // I am not sure why our coordinate frame is different, but, we can go back to
+                    // what the rest of the game logic is expecting here.
+                    int oy =  qRelativeRotation[1] * 512;
+                    int ox = -qRelativeRotation[2] * 512;
+
+                    bool bXPressed = ABS(ox) > 128;
+                    bool bXReleased = ABS(ox) < 80;
+                    bool bYWasTriggered = t48->receivedInputMask & 2;
+
+                    bool bYPressed = ABS(oy) > 128;
+                    bool bYReleased = ABS(oy) < 80;
+                    bool bXWasTriggered = t48->receivedInputMask & 1;
+
+                    if (!bYWasTriggered && bYPressed)
                     {
-                        if (ox > 128)
-                        {
-                            t48_gameInput(t48, PB_LEFT);
-                        }
-                        else if (ox < -128)
-                        {
-                            t48_gameInput(t48, PB_RIGHT);
-                        }
-                    }
-                    else
-                    {
-                        if (oy > 128)
+                        if (oy > 0)
                         {
                             t48_gameInput(t48, PB_DOWN);
                         }
-                        else if (oy < -128)
+                        else
                         {
                             t48_gameInput(t48, PB_UP);
                         }
+                        bYWasTriggered = true;
                     }
+                    if (bYWasTriggered && bYReleased )
+                    {
+                        bYWasTriggered = false;
+                    }
+
+                    if (!bXWasTriggered && bXPressed)
+                    {
+                        if (ox > 0)
+                        {
+                            t48_gameInput(t48, PB_LEFT);
+                        }
+                        else
+                        {
+                            t48_gameInput(t48, PB_RIGHT);
+                        }
+                        bXWasTriggered = true;
+                    }
+                    if (bXWasTriggered && bXReleased )
+                    {
+                        bXWasTriggered = false;
+                    }
+
+                    t48->receivedInputMask = (bYWasTriggered ? 2 : 0) | (bXWasTriggered ? 1 : 0);
+                    t48->lastIMUx = ox;
+                    t48->lastIMUy = oy;
                 }
             }
 
@@ -272,7 +317,19 @@ static void t48MainLoop(int64_t elapsedUs)
                 if (evt.down && (PB_A == evt.button || PB_B == evt.button))
                 {
                     soundPlaySfx(&t48->click, MIDI_SFX);
-                    t48->tiltControls = PB_B == evt.button;
+                    bool doTiltControls = PB_B == evt.button;
+
+                    if( doTiltControls )
+                    {
+                        esp_err_t aq = accelGetQuaternion( t48->quatBase );
+                        if (ESP_OK != aq)
+                        {
+                            doTiltControls = false;
+                        }
+                    }
+
+                    t48->tiltControls = doTiltControls;
+
                     // If a save game is detected, ask if the player wants to load it.
                     size_t blob = sizeof(t48GameSaveData_t);
                     readNvsBlob(nvsSaved2048, NULL, &blob);
@@ -605,7 +662,9 @@ static void t48BackgroundDraw(int16_t x __attribute__((unused)), int16_t y __att
                               int16_t w __attribute__((unused)), int16_t h __attribute__((unused)),
                               int16_t up __attribute__((unused)), int16_t upNum __attribute__((unused)))
 {
-    if (t48->tiltControls)
+    // Allow IMU integration while in menu, to make it so when we set the zero, it
+    // is at the time of the B press.
+    if (t48->tiltControls || t48->state == T48_START_SCREEN)
     {
         accelIntegrate();
     }

--- a/main/modes/games/2048/mode_2048.c
+++ b/main/modes/games/2048/mode_2048.c
@@ -234,17 +234,17 @@ static void t48MainLoop(int64_t elapsedUs)
             // Take accel input if cells aren't moving
             if (t48->tiltControls && !t48->cellsAnimating)
             {
-                //int16_t ox, oy, oz;
+                // int16_t ox, oy, oz;
                 float q[4];
-                esp_err_t aq = accelGetQuaternion( q );
+                esp_err_t aq = accelGetQuaternion(q);
                 if (ESP_OK == aq)
                 {
                     float qRelativeRotation[4];
 
                     // this takes about 36 flops.
-                    mathComputeQuaternionDeltaBetweenQuaternions( qRelativeRotation, t48->quatBase, q);
+                    mathComputeQuaternionDeltaBetweenQuaternions(qRelativeRotation, t48->quatBase, q);
 
-                    // qRelativeRotation represents the rotation from the initial state to now. 
+                    // qRelativeRotation represents the rotation from the initial state to now.
                     // The quaternion is:  [w, x, y, z]
                     //  the w term, more like the part that sums everything to a unit quaternion.
                     //  the x term is the amount of rotation around the x axis.
@@ -254,18 +254,18 @@ static void t48MainLoop(int64_t elapsedUs)
                     //
                     // I am not sure why our coordinate frame is different, but, we can go back to
                     // what the rest of the game logic is expecting here.
-                    int oy =  qRelativeRotation[1] * 512;
+                    int oy = qRelativeRotation[1] * 512;
                     int ox = -qRelativeRotation[2] * 512;
 
                     const int trigger = 104;
                     const int release = 80;
 
-                    bool bXPressed = ABS(ox) > trigger;
-                    bool bXReleased = ABS(ox) < release;
+                    bool bXPressed      = ABS(ox) > trigger;
+                    bool bXReleased     = ABS(ox) < release;
                     bool bYWasTriggered = t48->receivedInputMask & 2;
 
-                    bool bYPressed = ABS(oy) > trigger;
-                    bool bYReleased = ABS(oy) < release;
+                    bool bYPressed      = ABS(oy) > trigger;
+                    bool bYReleased     = ABS(oy) < release;
                     bool bXWasTriggered = t48->receivedInputMask & 1;
 
                     if (!bYWasTriggered && bYPressed)
@@ -280,7 +280,7 @@ static void t48MainLoop(int64_t elapsedUs)
                         }
                         bYWasTriggered = true;
                     }
-                    if (bYWasTriggered && bYReleased )
+                    if (bYWasTriggered && bYReleased)
                     {
                         bYWasTriggered = false;
                     }
@@ -297,23 +297,22 @@ static void t48MainLoop(int64_t elapsedUs)
                         }
                         bXWasTriggered = true;
                     }
-                    if (bXWasTriggered && bXReleased )
+                    if (bXWasTriggered && bXReleased)
                     {
                         bXWasTriggered = false;
                     }
 
                     t48->receivedInputMask = (bYWasTriggered ? 2 : 0) | (bXWasTriggered ? 1 : 0);
-                    t48->lastIMUx = ox;
-                    t48->lastIMUy = oy;
-
+                    t48->lastIMUx          = ox;
+                    t48->lastIMUy          = oy;
 
                     // Handle pushing the zero around. You can push it by pushing past the endstops.
-                    bool bXIsRailed = ABS(ox) > (trigger+2);
-                    bool bYIsRailed = ABS(ox) > (trigger+2);
+                    bool bXIsRailed = ABS(ox) > (trigger + 2);
+                    bool bYIsRailed = ABS(ox) > (trigger + 2);
                     if (bXIsRailed || bYIsRailed)
                     {
-                        const float fNudgeAmount = 0.04; 
-                        float qNudgeX[4] = { 0.999, 0.0, 0.0, 0.0 };
+                        const float fNudgeAmount = 0.04;
+                        float qNudgeX[4]         = {0.999, 0.0, 0.0, 0.0};
                         if (bXIsRailed)
                         {
                             qNudgeX[2] = ox > 0 ? -fNudgeAmount : fNudgeAmount;
@@ -323,7 +322,7 @@ static void t48MainLoop(int64_t elapsedUs)
                             qNudgeX[1] = oy < 0 ? -fNudgeAmount : fNudgeAmount;
                         }
                         mathQuatApply(t48->quatBase, t48->quatBase, qNudgeX);
-                        mathQuatNormalize( t48->quatBase, t48->quatBase );
+                        mathQuatNormalize(t48->quatBase, t48->quatBase);
                     }
                 }
             }
@@ -342,9 +341,9 @@ static void t48MainLoop(int64_t elapsedUs)
                     soundPlaySfx(&t48->click, MIDI_SFX);
                     bool doTiltControls = PB_B == evt.button;
 
-                    if( doTiltControls )
+                    if (doTiltControls)
                     {
-                        esp_err_t aq = accelGetQuaternion( t48->quatBase );
+                        esp_err_t aq = accelGetQuaternion(t48->quatBase);
                         if (ESP_OK != aq)
                         {
                             doTiltControls = false;

--- a/main/modes/games/2048/mode_2048.h
+++ b/main/modes/games/2048/mode_2048.h
@@ -126,6 +126,12 @@ typedef struct
     bool alreadyWon;                               ///< If the win screen has already displayed
     t48ModeStateEnum_t state;                      ///< Where in the game sequence we are
 
+    // Input for IMU-based 2048.
+    // Only used if tiltControls == true
+    float quatBase[4];
+    char  receivedInputMask;
+    int lastIMUx, lastIMUy;
+
     // Audio
     bool bgmIsPlaying; ///< Allows the BGM to restart
 

--- a/main/modes/games/2048/mode_2048.h
+++ b/main/modes/games/2048/mode_2048.h
@@ -129,7 +129,7 @@ typedef struct
     // Input for IMU-based 2048.
     // Only used if tiltControls == true
     float quatBase[4];
-    char  receivedInputMask;
+    char receivedInputMask;
     int lastIMUx, lastIMUy;
 
     // Audio


### PR DESCRIPTION
### Description

Improve 2048 game motion controls.

### Test Instructions

By playing on a swadge (Though admittedly an early prototype)

### Ticket Links

N/A

### Readiness Checklist
- [X] I have run `make format` to format the changes
- [X] I have compiled the firmware and the changes have no warnings
- [X] I have compiled the emulator and the changes have no warnings
- [X] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [N/A] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [N/A] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
