### PR TITLE
BBB update to stop the screaming.

### DIFF
--- a/main/modes/test/bongoTest/bongoTest.c
+++ b/main/modes/test/bongoTest/bongoTest.c
@@ -253,7 +253,11 @@ static void playWithBongo(int64_t elapsedUs)
         bt->player->mode              = MIDI_STREAMING;
         bt->player->streamingCallback = NULL;
         midiGmOn(bt->player);
-        midiPause(bt->player, false); 
+        midiPause(bt->player, false);
+        for (int idx = 0; idx < 6; idx++)
+        {
+            bt->hits[idx] = false;
+        }
     }
     if (bt->heat >= HEAT_CUTOFF)
     {

--- a/main/modes/test/bongoTest/bongoTest.c
+++ b/main/modes/test/bongoTest/bongoTest.c
@@ -23,6 +23,7 @@
 
 #define HEAT_CUTOFF 10
 #define DECAY_RATE  200000
+#define UNSITCK_VAL 250000
 
 //==============================================================================
 // Consts
@@ -44,6 +45,7 @@ typedef struct
 
     // Bongo
     bool hits[6];
+    int32_t unstickTimer;
 
     // Rainbows
     uint8_t bgColor;
@@ -139,7 +141,7 @@ static void abandonBongo(void)
 
 static void playWithBongo(int64_t elapsedUs)
 {
-    // Decay is the only constant
+    // Decay
     bt->heatDecay += elapsedUs;
     if (bt->heatDecay >= DECAY_RATE && bt->heat > 0)
     {
@@ -165,12 +167,14 @@ static void playWithBongo(int64_t elapsedUs)
     }
     setLeds(bt->leds, CONFIG_NUM_LEDS);
 
-    // Input me harder
+    bt->unstickTimer += elapsedUs;
+    // Input
     buttonEvt_t evt;
     while (checkButtonQueueWrapper(&evt))
     {
         if (evt.down)
         {
+            bt->unstickTimer = 0;
             if (evt.button & PB_A)
             {
                 bt->hits[0] = true;
@@ -211,6 +215,7 @@ static void playWithBongo(int64_t elapsedUs)
         }
         else if (!evt.down)
         {
+            bt->unstickTimer = 0;
             if (evt.button & PB_A)
             {
                 bt->hits[0] = false;
@@ -241,6 +246,15 @@ static void playWithBongo(int64_t elapsedUs)
             }
         }
     }
+    if (bt->unstickTimer >= UNSITCK_VAL)
+    {
+        bt->unstickTimer = 0;
+        midiPlayerReset(bt->player);
+        bt->player->mode              = MIDI_STREAMING;
+        bt->player->streamingCallback = NULL;
+        midiGmOn(bt->player);
+        midiPause(bt->player, false); 
+    }
     if (bt->heat >= HEAT_CUTOFF)
     {
         wsgPaletteSet(&bt->pal, c555, paletteHsvToHex((bt->bgColor + 128) % 255, 255, 255));
@@ -250,7 +264,7 @@ static void playWithBongo(int64_t elapsedUs)
         wsgPaletteSet(&bt->pal, c555, c555);
     }
 
-    // Draw me like a french poodle
+    // Draw
     // BG
     if (bt->heat >= HEAT_CUTOFF)
     {


### PR DESCRIPTION
### Description

Fixed the notes getting stuck on.

### Test Instructions

Emulator: Attempted to reproduce bug, was unable to hear the screaming.
Hardware: Attempted to reproduce bug, was unable to hear the screaming.

### Ticket Links

#374 

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
