### PR TITLE
Swadge hero fixes

### DIFF
--- a/main/display/font.c
+++ b/main/display/font.c
@@ -281,6 +281,8 @@ static const char* drawTextWordWrapFlags(const font_t* font, paletteColor_t colo
         // copy as much text as will fit into the buffer
         // leaving room for a null-terminator in case the string is longer
         strncpy(buf, textPtr, sizeof(buf) - 1);
+        // Always null terminate
+        buf[sizeof(buf) - 1] = 0;
 
         // shorten the text until it fits
         while (textX + textWidth(font, buf) > xMax)
@@ -301,6 +303,17 @@ static const char* drawTextWordWrapFlags(const font_t* font, paletteColor_t colo
 
             // Drop a null terminator to shrink the string
             *lastBreak = '\0';
+        }
+
+        // Look for newlines in the current line
+        for (int32_t i = 0; i < sizeof(buf); i++)
+        {
+            if ('\n' == buf[i])
+            {
+                // Newline found, end line here
+                buf[i] = 0;
+                break;
+            }
         }
 
         // the line must have enough space for the rest of the buffer

--- a/main/display/font.h
+++ b/main/display/font.h
@@ -79,6 +79,8 @@ const char* drawTextWordWrap(const font_t* font, paletteColor_t color, const cha
                              int16_t xMax, int16_t yMax);
 const char* drawTextWordWrapFixed(const font_t* font, paletteColor_t color, const char* text, int16_t xStart,
                                   int16_t yStart, int16_t* xOff, int16_t* yOff, int16_t xMax, int16_t yMax);
+const char* drawTextWordWrapCentered(const font_t* font, paletteColor_t color, const char* text, int16_t* xOff,
+                                     int16_t* yOff, int16_t xMax, int16_t yMax);
 uint16_t textWidth(const font_t* font, const char* text);
 uint16_t textWordWrapHeight(const font_t* font, const char* text, int16_t width, int16_t maxHeight);
 

--- a/main/modes/games/soko/sokoHelp.c
+++ b/main/modes/games/soko/sokoHelp.c
@@ -42,7 +42,7 @@ static const sokoHelpPage_t helpPages[] = {
     },
     {
         .title = controlTitle,
-        .text  = "When painting a floor, you can't step on wet paint. \nNo returning to a spot you've already been",
+        .text  = "When painting a floor, you can't step on wet paint. No returning to a spot you've already been.",
     },
     {
         .title = controlTitle,
@@ -76,7 +76,7 @@ static const sokoHelpPage_t helpPages[] = {
     },
     {
         .title = sokoModeName,
-        .text  = "Good luck and get painting! \n\n'I hope you enjoy my puzzles'\n - Hunter",
+        .text  = "Good luck and get painting!\n'I hope you enjoy my puzzles'\n- Hunter",
     },
 };
 

--- a/main/modes/games/swadgeHero/swadgeHero_game.c
+++ b/main/modes/games/swadgeHero/swadgeHero_game.c
@@ -812,10 +812,12 @@ void shDrawGame(shVars_t* sh)
     if (sh->leadInUs > 0)
     {
         int16_t tWidth = textWidth(&sh->rodin, sh->menuSong->name);
-        drawText(&sh->rodin, c555, sh->menuSong->name, (TFT_WIDTH - tWidth) / 2,
-                 (TFT_HEIGHT / 2) - sh->rodin.height - 2);
-        tWidth = textWidth(&sh->rodin, sh->menuSong->artist);
-        drawText(&sh->rodin, c555, sh->menuSong->artist, (TFT_WIDTH - tWidth) / 2, (TFT_HEIGHT / 2) + 2);
+        int16_t xOff   = 0;
+        int16_t yOff   = (TFT_HEIGHT / 2) - sh->rodin.height - 2;
+        drawTextWordWrapCentered(&sh->rodin, c555, sh->menuSong->name, &xOff, &yOff, TFT_WIDTH, TFT_HEIGHT);
+        xOff = 0;
+        yOff += sh->rodin.height + 8;
+        drawTextWordWrapCentered(&sh->rodin, c555, sh->menuSong->artist, &xOff, &yOff, TFT_WIDTH, TFT_HEIGHT);
     }
 
     // Set LEDs

--- a/main/modes/games/swadgeHero/swadgeHero_game.c
+++ b/main/modes/games/swadgeHero/swadgeHero_game.c
@@ -450,7 +450,7 @@ bool shRunTimers(shVars_t* sh, uint32_t elapsedUs)
     }
 
     // If failure is on and the song is playing
-    if (sh->failOn && songUs >= 0)
+    if (sh->failOn && (songUs >= 0) && (NUM_FAIL_METER_SAMPLES > sh->failSamples.length))
     {
         // Run a timer to sample the fail meter for a chart
         while (sh->failSampleInterval * sh->failSamples.length <= songUs)

--- a/main/modes/games/swadgeHero/swadgeHero_game.c
+++ b/main/modes/games/swadgeHero/swadgeHero_game.c
@@ -853,7 +853,7 @@ void shGameInput(shVars_t* sh, buttonEvt_t* evt)
     sh->btnState = evt->state;
 
     // This pauses and unpauses
-    if (PB_B < evt->button)
+    if (PB_START == evt->button)
     {
         if (evt->down)
         {
@@ -893,7 +893,13 @@ void shGameInput(shVars_t* sh, buttonEvt_t* evt)
     }
 
     // Find the note that corresponds to this button press
-    int32_t notePressed = sh->btnToNote[31 - __builtin_clz(evt->button)];
+    int32_t bnIdx = 31 - __builtin_clz(evt->button);
+    if (bnIdx >= ARRAY_SIZE(btnToNote_e))
+    {
+        // Invalid button press
+        return;
+    }
+    int32_t notePressed = sh->btnToNote[bnIdx];
 
     // If a note was pressed
     if (-1 != notePressed)

--- a/main/modes/games/swadgeHero/swadgeHero_game.c
+++ b/main/modes/games/swadgeHero/swadgeHero_game.c
@@ -811,9 +811,8 @@ void shDrawGame(shVars_t* sh)
     // Draw title and artist during lead in
     if (sh->leadInUs > 0)
     {
-        int16_t tWidth = textWidth(&sh->rodin, sh->menuSong->name);
-        int16_t xOff   = 0;
-        int16_t yOff   = (TFT_HEIGHT / 2) - sh->rodin.height - 2;
+        int16_t xOff = 0;
+        int16_t yOff = (TFT_HEIGHT / 2) - sh->rodin.height - 2;
         drawTextWordWrapCentered(&sh->rodin, c555, sh->menuSong->name, &xOff, &yOff, TFT_WIDTH, TFT_HEIGHT);
         xOff = 0;
         yOff += sh->rodin.height + 8;

--- a/main/modes/games/swadgeHero/swadgeHero_gameEnd.c
+++ b/main/modes/games/swadgeHero/swadgeHero_gameEnd.c
@@ -59,9 +59,9 @@ void shGameEndDraw(shVars_t* sh, int32_t elapsedUs)
     int16_t yOff = Y_MARGIN;
 
     // Draw the name
-    int16_t tWidth = textWidth(&sh->rodin, sh->songName);
-    int16_t xOff   = 0;
-    drawTextWordWrapCentered(&sh->rodin, c555, sh->songName, &xOff, &yOff, TFT_WIDTH, TFT_HEIGHT);
+    int16_t tWidth     = textWidth(&sh->rodin, sh->songName);
+    int16_t xOff_title = 0;
+    drawTextWordWrapCentered(&sh->rodin, c555, sh->songName, &xOff_title, &yOff, TFT_WIDTH, TFT_HEIGHT);
     yOff += sh->rodin.height + Y_MARGIN;
 
     // Draw background for the body

--- a/main/modes/games/swadgeHero/swadgeHero_gameEnd.c
+++ b/main/modes/games/swadgeHero/swadgeHero_gameEnd.c
@@ -55,16 +55,17 @@ void shGameEndInput(shVars_t* sh, buttonEvt_t* evt)
  */
 void shGameEndDraw(shVars_t* sh, int32_t elapsedUs)
 {
-    // Draw background for the body
-    fillDisplayArea(0, 2 * Y_MARGIN + sh->rodin.height, TFT_WIDTH, TFT_HEIGHT, c111);
-
     // Start here
-    int32_t yOff = Y_MARGIN;
+    int16_t yOff = Y_MARGIN;
 
     // Draw the name
     int16_t tWidth = textWidth(&sh->rodin, sh->songName);
-    drawText(&sh->rodin, c555, sh->songName, (TFT_WIDTH - tWidth) / 2, yOff);
+    int16_t xOff   = 0;
+    drawTextWordWrapCentered(&sh->rodin, c555, sh->songName, &xOff, &yOff, TFT_WIDTH, TFT_HEIGHT);
     yOff += sh->rodin.height + Y_MARGIN;
+
+    // Draw background for the body
+    fillDisplayArea(0, yOff, TFT_WIDTH, TFT_HEIGHT, c111);
 
     // This is the text area between the title and fail chart
     int32_t textAreaTop    = yOff;

--- a/main/modes/games/swadgeHero/swadgeHero_gameEnd.c
+++ b/main/modes/games/swadgeHero/swadgeHero_gameEnd.c
@@ -151,7 +151,11 @@ void shGameEndDraw(shVars_t* sh, int32_t elapsedUs)
         while (failNode)
         {
             // Draw a line from the last point to this one
-            xOff++;
+            if (failNode != sh->failSamples.first)
+            {
+                // Don't iterate on the very first point
+                xOff++;
+            }
             vec_t cPoint = {
                 .x = xOff,
                 .y = TFT_HEIGHT - Y_MARGIN - ((intptr_t)failNode->val) / 2,


### PR DESCRIPTION
### Description

* Added `drawTextWordWrapCentered()`, refactored `drawTextWordWrapFlags()`
    * Wrap & center long song names in Swadge Hero
* Clean Hunter Puzzle text
* Don't overdraw fail chart at the end of the song
* Fix phantom pause presses during Swadge Hero

### Test Instructions

* Play "Dance of the Cremulons" in Swadge Hero, see that text wraps nicely (except for menu title)
* View wrapped text elsewhere 
    * tutorial
    * UTTT instructions
    * Hunter Puzzle instructions
    * Sequencer instructions
    * 2048 load
    * Bigbug dialog
    * Chowa Grove tutorials

### Ticket Links

n/a

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
