### PR TITLE
Joystick input for Windows & Linux

### DIFF
--- a/emulator/src/extensions/emu_ext.c
+++ b/emulator/src/extensions/emu_ext.c
@@ -32,9 +32,8 @@
 //==============================================================================
 
 static const emuExtension_t* registeredExtensions[] = {
-    &touchEmuCallback,  &ledEmuExtension,   &fuzzerEmuExtension, &toolsEmuExtension,
-    &keymapEmuCallback, &modesEmuExtension, &replayEmuExtension, &midiEmuExtension,
-    &gamepadEmuExtension,
+    &touchEmuCallback,  &ledEmuExtension,    &fuzzerEmuExtension, &toolsEmuExtension,   &keymapEmuCallback,
+    &modesEmuExtension, &replayEmuExtension, &midiEmuExtension,   &gamepadEmuExtension,
 };
 
 //==============================================================================

--- a/emulator/src/extensions/emu_ext.c
+++ b/emulator/src/extensions/emu_ext.c
@@ -16,6 +16,7 @@
 #include "ext_touch.h"
 #include "ext_leds.h"
 #include "ext_fuzzer.h"
+#include "ext_gamepad.h"
 #include "ext_keymap.h"
 #include "ext_midi.h"
 #include "ext_modes.h"
@@ -33,6 +34,7 @@
 static const emuExtension_t* registeredExtensions[] = {
     &touchEmuCallback,  &ledEmuExtension,   &fuzzerEmuExtension, &toolsEmuExtension,
     &keymapEmuCallback, &modesEmuExtension, &replayEmuExtension, &midiEmuExtension,
+    &gamepadEmuExtension,
 };
 
 //==============================================================================

--- a/emulator/src/extensions/emu_ext.c
+++ b/emulator/src/extensions/emu_ext.c
@@ -250,6 +250,14 @@ void deinitExtensions(void)
         {
             free(paneInfo);
         }
+
+        if (extInfo->initialized)
+        {
+            if (extInfo->extension->fnDeinitCb)
+            {
+                extInfo->extension->fnDeinitCb();
+            }
+        }
         free(extInfo);
     }
 }

--- a/emulator/src/extensions/emu_ext.c
+++ b/emulator/src/extensions/emu_ext.c
@@ -201,7 +201,7 @@ static void preloadExtensions(void)
 }
 
 /**
- * @brief
+ * @brief Initializes all registered emulator extensions
  *
  * @param args
  */
@@ -233,7 +233,7 @@ void initExtensions(emuArgs_t* args)
 }
 
 /**
- * @brief
+ * @brief Deinitializes all registered emulator extensions
  *
  */
 void deinitExtensions(void)

--- a/emulator/src/extensions/emu_ext.c
+++ b/emulator/src/extensions/emu_ext.c
@@ -582,7 +582,22 @@ void layoutPanes(int32_t winW, int32_t winH, int32_t screenW, int32_t screenH, e
           + (winH - winPanes[PANE_TOP].paneH - winPanes[PANE_BOTTOM].paneH - screenPane->paneH - topDivH - bottomDivH)
                 / 2;
 
-    winPanes[PANE_BOTTOM].paneX = screenPane->paneX;
+    // Center the screen in the window if it's bigger
+    if (paneInfos[PANE_LEFT].count == 0 && paneInfos[PANE_RIGHT].count == 0)
+    {
+        screenPane->paneX = (winW - screenPane->paneW) / 2;
+
+        winPanes[PANE_BOTTOM].paneX = 0;
+        winPanes[PANE_TOP].paneX    = 0;
+
+        winPanes[PANE_BOTTOM].paneW = winW;
+        winPanes[PANE_TOP].paneW    = winW;
+    }
+    else
+    {
+        winPanes[PANE_BOTTOM].paneX = screenPane->paneX;
+        winPanes[PANE_TOP].paneX    = screenPane->paneX;
+    }
     winPanes[PANE_BOTTOM].paneY = screenPane->paneY + screenPane->paneH + bottomDivH;
 
 ///< Macro for calculating the offset of the current sub-pane within the overall pane

--- a/emulator/src/extensions/emu_ext.h
+++ b/emulator/src/extensions/emu_ext.h
@@ -181,6 +181,13 @@ typedef struct
     bool (*fnInitCb)(emuArgs_t* emuArgs);
 
     /**
+     * @brief Function to be called just before the emulator exits
+     *
+     * This callback should be used to free any memory or resources the extension has allocated.
+    */
+    void (*fnDeinitCb)(void);
+
+    /**
      * @brief Function to be called before an emulator frame is rendered
      *
      * This is the ideal location to inject button presses and other events into the emulator,

--- a/emulator/src/extensions/emu_ext.h
+++ b/emulator/src/extensions/emu_ext.h
@@ -184,7 +184,7 @@ typedef struct
      * @brief Function to be called just before the emulator exits
      *
      * This callback should be used to free any memory or resources the extension has allocated.
-    */
+     */
     void (*fnDeinitCb)(void);
 
     /**

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -440,7 +440,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                         }
                         else
                         {
-                            event->value = CLAMP(32 * getCos1024(((new->dwPOV / 100) + 90) % 360), -32768, 32767);
+                            event->value = CLAMP(-32 * getCos1024(((new->dwPOV / 100) + 90) % 360), -32768, 32767);
                         }
 
                         winData->pendingPov = true;
@@ -456,7 +456,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                         }
                         else
                         {
-                            event->value = CLAMP(32 * getSin1024(((new->dwPOV / 100) + 90) % 360), -32768, 32767);
+                            event->value = CLAMP(-32 * getSin1024(((new->dwPOV / 100) + 90) % 360), -32768, 32767);
                         }
 
                         winData->pendingPov = false;

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -315,8 +315,8 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                 // 5. If nothing is different, set pendingState = false;
                 JOYINFOEX winEvent = {0};
                 // what the hell kind of API requires this
-                winEvent.dwSize = sizeof(JOYINFOEX);
-                winEvent.dwFlags = JOY_RETURNALL;
+                winEvent.dwSize = sizeof(JOYINFOEX)
+                winEvent.dwFlags = JOY_RETURNALL | JOY_RETURNPOV;
 
                 MMRESULT result = joyGetPosEx(winData->deviceNum, &winEvent);
 
@@ -424,7 +424,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                         return true;
                     }
                 }
-                else if ((new->dwFlags & JOY_RETURNPOVCTS) && cur->dwPOV != new->dwPOV)
+                else if ((new->dwFlags & JOY_RETURNPOV) && cur->dwPOV != new->dwPOV)
                 {
                     // This is kinda weird!
                     // This is because we're splitting a single POV hat event into two discrete axes

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -16,7 +16,7 @@
 #include <math.h>
 #include <stdint.h>
 
-#if defined(EMU_WINDOWN)
+#if defined(EMU_WINDOWS)
 #include <Windows.h>
 #include <joystickapi.h>
 #elif defined(EMU_LINUX)

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -335,7 +335,8 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
 
             if (winData->pendingState)
             {
-#define CALC_AXIS(n, val) ((n - winData->axisMins[n]) * 32767 / (winData->axisMaxs[n] - winData->axisMins[n]))
+//#define CALC_AXIS(n, val) ((val - winData->axisMins[n]) * 32767 / (winData->axisMaxs[n] - winData->axisMins[n]))
+#define CALC_AXIS(n, val) (((val) - winData->axisMins[n]) * 65535 / ((winData->axisMaxs[n] - winData->axisMins[n])) / 2 - (32768 * (winData->axisMaxs[n] - winData->axisMins[n]) / 65536))
                 JOYINFOEX* cur = &winData->curState;
                 JOYINFOEX* new = &winData->newState;
                 if (cur->dwXpos != new->dwXpos)

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -335,8 +335,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
 
             if (winData->pendingState)
             {
-//#define CALC_AXIS(n, val) ((val - winData->axisMins[n]) * 32767 / (winData->axisMaxs[n] - winData->axisMins[n]))
-#define CALC_AXIS(n, val) (((val) - winData->axisMins[n]) * 65535 / ((winData->axisMaxs[n] - winData->axisMins[n])) / 2 - (32768 * (winData->axisMaxs[n] - winData->axisMins[n]) / 65536 / 2))
+#define CALC_AXIS(n, val) (val - 32767)
                 JOYINFOEX* cur = &winData->curState;
                 JOYINFOEX* new = &winData->newState;
                 if (cur->dwXpos != new->dwXpos)

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -322,7 +322,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
 
                 if (result == JOYERR_NOERROR)
                 {
-                    if (memcmp(&winEvent, &winData->curState, sizeof(JOYINFOEX)))
+                    if (winEvent.dwFlags && memcmp(&winEvent, &winData->curState, sizeof(JOYINFOEX)))
                     {
                         // The new data is different from the current data so copy it over
                         memcpy(&winData->newState, &winEvent, sizeof(JOYINFOEX));

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -316,7 +316,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                 JOYINFOEX winEvent = {0};
                 // what the hell kind of API requires this
                 winEvent.dwSize = sizeof(JOYINFOEX);
-                winEvent.dwFlags = 0;
+                winEvent.dwFlags = JOY_RETURNALL;
 
                 MMRESULT result = joyGetPosEx(winData->deviceNum, &winEvent);
 

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -397,7 +397,8 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                 }
                 else if (cur->dwButtons != new->dwButtons)
                 {
-                    uint32_t change = cur->dwButtons ^ new->dwButtons;
+                    printf("Buttons changed, %x -> %x\n", cur->dwButtons, new->dwButtons);
+                    DWORD change = cur->dwButtons ^ new->dwButtons;
                     if (change != 0)
                     {
                         uint32_t buttonIdx = __builtin_ctz(change);

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -315,7 +315,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                 // 5. If nothing is different, set pendingState = false;
                 JOYINFOEX winEvent = {0};
                 // what the hell kind of API requires this
-                winEvent.dwSize = sizeof(JOYINFOEX)
+                winEvent.dwSize = sizeof(JOYINFOEX);
                 winEvent.dwFlags = JOY_RETURNALL | JOY_RETURNPOV;
 
                 MMRESULT result = joyGetPosEx(winData->deviceNum, &winEvent);

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -345,6 +345,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                     event->axis = 0;
                     event->value = CALC_AXIS(0, new->dwXpos);
                     cur->dwXpos = new->dwXpos;
+                    applyEvent(joystick, event);
                     return true;
                 }
                 else if (cur->dwYpos != new->dwYpos)
@@ -353,6 +354,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                     event->axis = 1;
                     event->value = CALC_AXIS(1, new->dwYpos);
                     cur->dwYpos = new->dwYpos;
+                    applyEvent(joystick, event);
                     return true;
                 }
                 else if (cur->dwZpos != new->dwZpos)
@@ -361,6 +363,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                     event->axis = 2;
                     event->value = CALC_AXIS(2, new->dwZpos);
                     cur->dwZpos = new->dwZpos;
+                    applyEvent(joystick, event);
                     return true;
                 }
                 else if (cur->dwRpos != new->dwRpos)
@@ -369,6 +372,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                     event->axis = 3;
                     event->value = CALC_AXIS(3, new->dwRpos);
                     cur->dwRpos = new->dwRpos;
+                    applyEvent(joystick, event);
                     return true;
                 }
                 else if (cur->dwUpos != new->dwUpos)
@@ -377,6 +381,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                     event->axis = 4;
                     event->value = CALC_AXIS(4, new->dwUpos);
                     cur->dwUpos = new->dwUpos;
+                    applyEvent(joystick, event);
                     return true;
                 }
                 else if (cur->dwVpos != new->dwVpos)
@@ -385,6 +390,8 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                     event->axis = 5;
                     event->value = CALC_AXIS(5, new->dwVpos);
                     cur->dwVpos = new->dwVpos;
+                    applyEvent(joystick, event);
+                    return true;
                 }
                 else if (cur->dwButtons != new->dwButtons)
                 {
@@ -409,15 +416,18 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                             cur->dwButtons &= ~(1 << buttonIdx);
                         }
 
+                        applyEvent(joystick, event);
                         return true;
                     }
                 }
                 else if (cur->dwPOV != new->dwPOV)
                 {
+                    // TODO this needs to be split further into two different events...
                     event->type = AXIS;
                     event->axis = 6;
                     event->value = new->dwPOV;
                     cur->dwPOV = new->dwPOV;
+                    applyEvent(joystick, event);
                     return true;
                 }
                 else

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -1,0 +1,382 @@
+#include "ext_gamepad.h"
+
+#include "emu_utils.h"
+#include "hdw-btn_emu.h"
+#include "hdw-imu_emu.h"
+#include "macros.h"
+
+#include <esp_log.h>
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <math.h>
+
+#if defined(EMU_WINDOWN)
+#elif defined(EMU_LINUX)
+#include <linux/joystick.h>
+#elif defined(EMU_MACOS)
+#else
+#error "Unrecognized platform"
+#endif
+
+// Defines the mapping of the default Swadge Gamepad mode
+#define TOUCH_AXIS_X 0
+#define TOUCH_AXIS_Y 1
+
+#define ACCEL_AXIS_X 5
+#define ACCEL_AXIS_Y 3
+#define ACCEL_AXIS_Z 4
+
+#define DPAD_AXIS_X 6
+#define DPAD_AXIS_Y 7
+
+const buttonBit_t joystickButtonMap[] = {
+    PB_A,
+    PB_B,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    PB_SELECT,
+    PB_START,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+};
+
+typedef enum
+{
+    BUTTON,
+    AXIS,
+} emuJoystickEventType_t;
+
+typedef struct
+{
+    emuJoystickEventType_t type;
+    union {
+        uint16_t axis;
+        uint16_t button;
+    };
+    int16_t value;
+
+} emuJoystickEvent_t;
+
+typedef struct
+{
+    int numAxes;
+    int numButtons;
+    void* data;
+    int16_t* axisData;
+    uint8_t* buttonData;
+} emuJoystick_t;
+
+bool gamepadInitCb(emuArgs_t* args);
+void gamepadPreFrameCb(uint64_t frame);
+
+bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event);
+bool gamepadConnect(emuJoystick_t* joystick);
+
+ emuExtension_t gamepadEmuExtension = {
+    .name = "gamepad",
+    .fnInitCb = gamepadInitCb,
+    .fnPreFrameCb = gamepadPreFrameCb,
+ };
+
+ static emuJoystick_t joystick = {0};
+
+#if defined(EMU_LINUX)
+
+bool gamepadConnect(emuJoystick_t* joystick)
+{
+    const char* device = NULL;
+    int jsFd;
+#ifdef EMU_LINUX
+    device = "/dev/input/js0";
+
+    jsFd = open(device, O_RDONLY | O_NONBLOCK);
+    if (jsFd == -1)
+    {
+        ESP_LOGE("Gamepad", "Failed to open joystick device /dev/input/js0");
+        return false;
+    }
+
+    joystick->data = (void*)(jsFd);
+    uint8_t buttons;
+    if (ioctl(jsFd, JSIOCGBUTTONS, &buttons) == -1)
+    {
+        joystick->numButtons = 0;
+        joystick->buttonData = NULL;
+    }
+    else
+    {
+        joystick->numButtons = buttons;
+        joystick->buttonData = calloc(buttons, sizeof(uint8_t));
+    }
+
+    uint8_t axes;
+    if (ioctl(jsFd, JSIOCGAXES, &axes) == -1)
+    {
+        joystick->numAxes = 0;
+    }
+    else
+    {
+        joystick->numAxes = axes;
+        joystick->axisData = calloc(axes, sizeof(int16_t));
+    }
+
+    return true;
+#else
+    return false;
+#endif
+}
+
+static void applyEvent(emuJoystick_t* joystick, const emuJoystickEvent_t* event)
+{
+    if (event)
+    {
+        switch (event->type)
+        {
+            case AXIS:
+            {
+                if (event->axis < joystick->numAxes)
+                {
+                    joystick->axisData[event->axis] = event->value;
+                }
+                break;
+            }
+
+            case BUTTON:
+            {
+                joystick->buttonData[event->button] = (event->value) ? 1 : 0;
+                break;
+            }
+
+            default: break;
+        }
+    }
+}
+
+bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
+{
+    if (joystick && joystick->data)
+    {
+#ifdef EMU_LINUX
+        struct js_event linuxEvent;
+
+        errno = 0;
+        int count = read((int)joystick->data, &linuxEvent, sizeof(struct js_event));
+        if (count >= (int)sizeof(struct js_event))
+        {
+            switch (linuxEvent.type)
+            {
+                case JS_EVENT_BUTTON:
+                {
+                    event->type = BUTTON;
+                    event->button = linuxEvent.number;
+                    event->value = linuxEvent.value;
+                    break;
+                }
+
+                case JS_EVENT_AXIS:
+                {
+                    event->type = AXIS;
+                    event->axis = linuxEvent.number;
+                    event->value = linuxEvent.value;
+                    break;
+                }
+
+                default:
+                {
+                }
+            }
+
+            applyEvent(joystick, event);
+            return true;
+        }
+        else if (count <= 0)
+        {
+            if (errno == EAGAIN)
+            {
+                return false;
+            }
+
+            ESP_LOGE("GamepadExt", "Failed to read, disconnecting gamepad");
+            if (joystick->axisData)
+            {
+                free(joystick->axisData);
+                joystick->axisData = NULL;
+            }
+            if (joystick->buttonData)
+            {
+                free(joystick->buttonData);
+                joystick->buttonData = NULL;
+            }
+            
+            close((int)joystick->data);
+            joystick->data = NULL;
+            return false;
+        }
+        else
+        {
+            ESP_LOGE("GamepadExt", "Short read of %d", count);
+            return false;
+        }
+#endif
+    }
+
+    return false;
+}
+
+bool gamepadInitCb(emuArgs_t* args)
+{
+    if (gamepadConnect(&joystick))
+    {
+        ESP_LOGI("GamepadExt", "Connected to joystick with %d axes and %d buttons\n", joystick.numAxes, joystick.numButtons);
+        return true;
+    }
+
+    return false;
+}
+
+void gamepadPreFrameCb(uint64_t frame)
+{
+    emuJoystickEvent_t event;
+    while (gamepadReadEvent(&joystick, &event))
+    {
+        switch (event.type)
+        {
+            case BUTTON:
+            {
+                if (event.button < 32 && joystickButtonMap[event.button])
+                {
+                    emulatorInjectButton(joystickButtonMap[event.button], event.value != 0);
+                }
+                break;
+            }
+
+            case AXIS:
+            {   
+                switch (event.axis)
+                {
+                    case TOUCH_AXIS_X:
+                    case TOUCH_AXIS_Y:
+                    {
+                        // Joystick data comes in as a value from (-2**15) to (2**15-1)
+                        // We need to take that down to (-128) to (127) (divide by 8)
+                        // Then need to take the atan2 of it
+                        double x = (double)joystick.axisData[TOUCH_AXIS_X];
+                        double y = (double)joystick.axisData[TOUCH_AXIS_Y];
+
+                        if (x == 0 && y == 0)
+                        {
+                            emulatorSetTouchJoystick(0, 0, 0);
+                        }
+                        else
+                        {
+                            const double maxRadius = 1024;
+                            
+                            double angle = atan2(-y, x);
+                            double angleDegrees = (angle * 180) / M_PI;
+                            int radius = CLAMP(sqrt(x * x + y * y) * maxRadius / 32768, 0, maxRadius);
+
+                            int angleDegreesRounded = (int)(angleDegrees + 360) % 360;
+                            emulatorSetTouchJoystick(CLAMP(angleDegreesRounded, 0, 359), radius, 1024);
+                        }
+                        break;
+                    }
+
+                    case ACCEL_AXIS_X:
+                    case ACCEL_AXIS_Y:
+                    case ACCEL_AXIS_Z:
+                    {
+                        int16_t accelX = joystick.axisData[ACCEL_AXIS_X] / 128;
+                        int16_t accelY = joystick.axisData[ACCEL_AXIS_Y] / 128;
+                        int16_t accelZ = joystick.axisData[ACCEL_AXIS_Z] / 128;
+
+                        emulatorSetAccelerometer(accelX, accelY, accelZ);
+                        break;
+                    }
+
+                    case DPAD_AXIS_X:
+                    case DPAD_AXIS_Y:
+                    {
+                        uint8_t val = 0;
+                        buttonBit_t curState = 0;
+                        if (joystick.axisData[DPAD_AXIS_X] < 0)
+                        {
+                            curState |= PB_LEFT;
+                        }
+                        else if (joystick.axisData[DPAD_AXIS_X] > 0)
+                        {
+                            curState |= PB_RIGHT;
+                        }
+
+                        if (joystick.axisData[DPAD_AXIS_Y] < 0)
+                        {
+                            curState |= PB_UP;
+                        }
+                        else if (joystick.axisData[DPAD_AXIS_Y] > 0)
+                        {
+                            curState |= PB_DOWN;
+                        }
+
+                        buttonBit_t lastState = emulatorGetButtonState();
+                        buttonBit_t changes = (lastState ^ curState) & ((1 << 8) - 1);
+
+                        if (changes & PB_UP)
+                        {
+                            emulatorInjectButton(PB_UP, (curState & PB_UP));
+                        }
+                        else if (changes & PB_DOWN)
+                        {
+                            emulatorInjectButton(PB_DOWN, (curState & PB_DOWN));
+                        }
+
+                        if (changes & PB_LEFT)
+                        {
+                            emulatorInjectButton(PB_LEFT, (curState & PB_LEFT));
+                        }
+                        else if (changes & PB_RIGHT)
+                        {
+                            emulatorInjectButton(PB_RIGHT, (curState & PB_RIGHT));
+                        }
+                        break;
+                    }
+
+                    default:
+                    {
+                        break;
+                    }
+                }
+                break;
+            }
+        }
+    }
+}
+
+#endif

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -333,7 +333,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                         event->type = BUTTON;
                         event->button = buttonIdx;
 
-                        if (new->buttons & (1 << buttonIdx))
+                        if (new->dwButtons & (1 << buttonIdx))
                         {
                             // Button pressed
                             event->value = 1;

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -151,6 +151,20 @@ bool gamepadConnect(emuJoystick_t* joystick)
                 joystick->numButtons = caps.wNumButtons;
                 joystick->numAxes = caps.wNumAxes;
 
+                if (joystick->numButtons > 0)
+                {
+                    joystick->buttonData = calloc(joystick->numButtons, sizeof(uint8_t));
+                }
+                else
+                {
+                    joystick->buttonData = NULL;
+                }
+
+                if (joystick->numAxes > 0)
+                {
+                    joystick->axisData = calloc(joystick->numAxes, sizeof(int16_t));
+                }
+
                 joystick->data = data;
 
                 return true;

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -341,7 +341,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
 #define CALC_AXIS(n, val) (val - 32767)
                 JOYINFOEX* cur = &winData->curState;
                 JOYINFOEX* new = &winData->newState;
-                if (cur->dwXpos != new->dwXpos)
+                if ((new->dwFlags & JOY_RETURNX) && cur->dwXpos != new->dwXpos)
                 {
                     event->type = AXIS;
                     event->axis = 0;
@@ -350,7 +350,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                     applyEvent(joystick, event);
                     return true;
                 }
-                else if (cur->dwYpos != new->dwYpos)
+                else if ((new->dwFlags & JOY_RETURNY) && cur->dwYpos != new->dwYpos)
                 {
                     event->type = AXIS;
                     event->axis = 1;
@@ -359,7 +359,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                     applyEvent(joystick, event);
                     return true;
                 }
-                else if (cur->dwZpos != new->dwZpos)
+                else if ((new->dwFlags & JOY_RETURNZ) && cur->dwZpos != new->dwZpos)
                 {
                     event->type = AXIS;
                     event->axis = 2;
@@ -368,7 +368,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                     applyEvent(joystick, event);
                     return true;
                 }
-                else if (cur->dwRpos != new->dwRpos)
+                else if ((new->dwFlags & JOY_RETURNR) && cur->dwRpos != new->dwRpos)
                 {
                     event->type = AXIS;
                     event->axis = 3;
@@ -377,7 +377,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                     applyEvent(joystick, event);
                     return true;
                 }
-                else if (cur->dwUpos != new->dwUpos)
+                else if ((new->dwFlags & JOY_RETURNU) && cur->dwUpos != new->dwUpos)
                 {
                     event->type = AXIS;
                     event->axis = 4;
@@ -386,7 +386,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                     applyEvent(joystick, event);
                     return true;
                 }
-                else if (cur->dwVpos != new->dwVpos)
+                else if ((new->dwFlags & JOY_RETURNV) && cur->dwVpos != new->dwVpos)
                 {
                     event->type = AXIS;
                     event->axis = 5;
@@ -395,9 +395,10 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                     applyEvent(joystick, event);
                     return true;
                 }
-                else if (cur->dwButtons != new->dwButtons)
+                else if ((new->dwFlags & JOY_RETURNBUTTONS) && cur->dwButtons != new->dwButtons)
                 {
                     printf("Buttons changed, %x -> %x\n", cur->dwButtons, new->dwButtons);
+
                     DWORD change = cur->dwButtons ^ new->dwButtons;
                     if (change != 0)
                     {
@@ -423,7 +424,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                         return true;
                     }
                 }
-                else if (cur->dwPOV != new->dwPOV)
+                else if ((new->dwFlags & JOY_RETURNPOVCTS) && cur->dwPOV != new->dwPOV)
                 {
                     // This is kinda weird!
                     // This is because we're splitting a single POV hat event into two discrete axes

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -131,7 +131,6 @@ bool gamepadConnect(emuJoystick_t* joystick)
 #if defined(EMU_WINDOWS)
     UINT numDevices = joyGetNumDevs();
     JOYCAPS caps;
-    bool set = false;
     for (int i = 0; i < numDevices; i++)
     {
         MMRESULT result = joyGetDevCaps(i, &caps, sizeof(caps));
@@ -205,7 +204,7 @@ bool gamepadConnect(emuJoystick_t* joystick)
 
                             default: break;
                         }
-                        winData->axisMins[axis] min;
+                        winData->axisMins[axis] = min;
                         winData->axisMaxs[axis] = max;
 
                         const char axisIds[] = "XYZRUV";
@@ -336,7 +335,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
 
             if (winData->pendingState)
             {
-#define CALC_AXIS(n, val) ((n - winData->axisMins[n]) * 32767 / (winData->axisMaxs[n] - winData->axisMaxs[n]))
+#define CALC_AXIS(n, val) ((n - winData->axisMins[n]) * 32767 / (winData->axisMaxs[n] - winData->axisMins[n]))
                 JOYINFOEX* cur = &winData->curState;
                 JOYINFOEX* new = &winData->newState;
                 if (cur->dwXpos != new->dwXpos)

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -440,7 +440,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                         }
                         else
                         {
-                            event->value = CLAMP(32 * getCos1024(new->dwPOV / 100), -32768, 32767);
+                            event->value = CLAMP(32 * getCos1024(((new->dwPOV / 100) + 90) % 360), -32768, 32767);
                         }
 
                         winData->pendingPov = true;
@@ -456,7 +456,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                         }
                         else
                         {
-                            event->value = CLAMP(32 * getSin1024(new->dwPOV / 100), -32768, 32767);
+                            event->value = CLAMP(32 * getSin1024(((new->dwPOV / 100) + 90) % 360), -32768, 32767);
                         }
 
                         winData->pendingPov = false;

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -336,7 +336,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
             if (winData->pendingState)
             {
 //#define CALC_AXIS(n, val) ((val - winData->axisMins[n]) * 32767 / (winData->axisMaxs[n] - winData->axisMins[n]))
-#define CALC_AXIS(n, val) (((val) - winData->axisMins[n]) * 65535 / ((winData->axisMaxs[n] - winData->axisMins[n])) / 2 - (32768 * (winData->axisMaxs[n] - winData->axisMins[n]) / 65536))
+#define CALC_AXIS(n, val) (((val) - winData->axisMins[n]) * 65535 / ((winData->axisMaxs[n] - winData->axisMins[n])) / 2 - (32768 * (winData->axisMaxs[n] - winData->axisMins[n]) / 65536 / 2))
                 JOYINFOEX* cur = &winData->curState;
                 JOYINFOEX* new = &winData->newState;
                 if (cur->dwXpos != new->dwXpos)

--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -16,12 +16,12 @@
 #include <stdint.h>
 
 #if defined(EMU_WINDOWS)
-#include <Windows.h>
-#include <joystickapi.h>
+    #include <Windows.h>
+    #include <joystickapi.h>
 #elif defined(EMU_LINUX)
-#include <linux/joystick.h>
-#include <fcntl.h>
-#include <unistd.h>
+    #include <linux/joystick.h>
+    #include <fcntl.h>
+    #include <unistd.h>
 #elif defined(EMU_MACOS)
 #endif
 
@@ -37,38 +37,7 @@
 #define DPAD_AXIS_Y 7
 
 const buttonBit_t joystickButtonMap[] = {
-    PB_A,
-    PB_B,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    PB_SELECT,
-    PB_START,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
+    PB_A, PB_B, 0, 0, 0, 0, 0, 0, 0, 0, PB_SELECT, PB_START, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 };
 
 #ifdef EMU_WINDOWS
@@ -94,7 +63,8 @@ typedef enum
 typedef struct
 {
     emuJoystickEventType_t type;
-    union {
+    union
+    {
         uint16_t axis;
         uint16_t button;
     };
@@ -120,9 +90,9 @@ bool gamepadConnect(emuJoystick_t* joystick);
 void gamepadDisconnect(emuJoystick_t* joystick);
 
 emuExtension_t gamepadEmuExtension = {
-    .name = "gamepad",
-    .fnInitCb = gamepadInitCb,
-    .fnDeinitCb = gamepadDeinitCb,
+    .name         = "gamepad",
+    .fnInitCb     = gamepadInitCb,
+    .fnDeinitCb   = gamepadDeinitCb,
     .fnPreFrameCb = gamepadPreFrameCb,
 };
 
@@ -148,7 +118,7 @@ bool gamepadConnect(emuJoystick_t* joystick)
                 winData->deviceNum = i;
 
                 joystick->numButtons = caps.wNumButtons;
-                joystick->numAxes = caps.wNumAxes;
+                joystick->numAxes    = caps.wNumAxes;
 
                 if (caps.wCaps & JOYCAPS_HASPOV)
                 {
@@ -212,7 +182,7 @@ bool gamepadConnect(emuJoystick_t* joystick)
     }
     else
     {
-        joystick->numAxes = axes;
+        joystick->numAxes  = axes;
         joystick->axisData = calloc(axes, sizeof(int16_t));
     }
 
@@ -239,7 +209,7 @@ void gamepadDisconnect(emuJoystick_t* joystick)
     {
         free(joystick->axisData);
         joystick->axisData = NULL;
-        joystick->numAxes = 0;
+        joystick->numAxes  = 0;
     }
 
     if (joystick->buttonData)
@@ -271,7 +241,8 @@ static void applyEvent(emuJoystick_t* joystick, const emuJoystickEvent_t* event)
                 break;
             }
 
-            default: break;
+            default:
+                break;
         }
     }
 }
@@ -283,7 +254,8 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
 #if defined(EMU_WINDOWS)
         emuWinJoyData_t* winData = (emuWinJoyData_t*)joystick->data;
 
-        do {
+        do
+        {
             if (!winData->pendingState)
             {
                 // If we're here, we have successfully transmitted all state changes via events
@@ -296,7 +268,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                 // 5. If nothing is different, set pendingState = false;
                 JOYINFOEX winEvent = {0};
                 // what the hell kind of API requires this
-                winEvent.dwSize = sizeof(JOYINFOEX);
+                winEvent.dwSize  = sizeof(JOYINFOEX);
                 winEvent.dwFlags = JOY_RETURNALL | JOY_RETURNPOV;
 
                 MMRESULT result = joyGetPosEx(winData->deviceNum, &winEvent);
@@ -319,71 +291,71 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
 
             if (winData->pendingState)
             {
-#define CALC_AXIS(n, val) (val - 32767)
+    #define CALC_AXIS(n, val) (val - 32767)
                 JOYINFOEX* cur = &winData->curState;
                 JOYINFOEX* new = &winData->newState;
-                if ((new->dwFlags & JOY_RETURNX) && cur->dwXpos != new->dwXpos)
+                if ((new->dwFlags& JOY_RETURNX) && cur->dwXpos != new->dwXpos)
                 {
-                    event->type = AXIS;
-                    event->axis = 0;
+                    event->type  = AXIS;
+                    event->axis  = 0;
                     event->value = CALC_AXIS(0, new->dwXpos);
-                    cur->dwXpos = new->dwXpos;
+                    cur->dwXpos  = new->dwXpos;
                     applyEvent(joystick, event);
                     return true;
                 }
-                else if ((new->dwFlags & JOY_RETURNY) && cur->dwYpos != new->dwYpos)
+                else if ((new->dwFlags& JOY_RETURNY) && cur->dwYpos != new->dwYpos)
                 {
-                    event->type = AXIS;
-                    event->axis = 1;
+                    event->type  = AXIS;
+                    event->axis  = 1;
                     event->value = CALC_AXIS(1, new->dwYpos);
-                    cur->dwYpos = new->dwYpos;
+                    cur->dwYpos  = new->dwYpos;
                     applyEvent(joystick, event);
                     return true;
                 }
-                else if ((new->dwFlags & JOY_RETURNZ) && cur->dwZpos != new->dwZpos)
+                else if ((new->dwFlags& JOY_RETURNZ) && cur->dwZpos != new->dwZpos)
                 {
-                    event->type = AXIS;
-                    event->axis = 2;
+                    event->type  = AXIS;
+                    event->axis  = 2;
                     event->value = CALC_AXIS(2, new->dwZpos);
-                    cur->dwZpos = new->dwZpos;
+                    cur->dwZpos  = new->dwZpos;
                     applyEvent(joystick, event);
                     return true;
                 }
-                else if ((new->dwFlags & JOY_RETURNR) && cur->dwRpos != new->dwRpos)
+                else if ((new->dwFlags& JOY_RETURNR) && cur->dwRpos != new->dwRpos)
                 {
-                    event->type = AXIS;
-                    event->axis = 3;
+                    event->type  = AXIS;
+                    event->axis  = 3;
                     event->value = CALC_AXIS(3, new->dwRpos);
-                    cur->dwRpos = new->dwRpos;
+                    cur->dwRpos  = new->dwRpos;
                     applyEvent(joystick, event);
                     return true;
                 }
-                else if ((new->dwFlags & JOY_RETURNU) && cur->dwUpos != new->dwUpos)
+                else if ((new->dwFlags& JOY_RETURNU) && cur->dwUpos != new->dwUpos)
                 {
-                    event->type = AXIS;
-                    event->axis = 4;
+                    event->type  = AXIS;
+                    event->axis  = 4;
                     event->value = CALC_AXIS(4, new->dwUpos);
-                    cur->dwUpos = new->dwUpos;
+                    cur->dwUpos  = new->dwUpos;
                     applyEvent(joystick, event);
                     return true;
                 }
-                else if ((new->dwFlags & JOY_RETURNV) && cur->dwVpos != new->dwVpos)
+                else if ((new->dwFlags& JOY_RETURNV) && cur->dwVpos != new->dwVpos)
                 {
-                    event->type = AXIS;
-                    event->axis = 5;
+                    event->type  = AXIS;
+                    event->axis  = 5;
                     event->value = CALC_AXIS(5, new->dwVpos);
-                    cur->dwVpos = new->dwVpos;
+                    cur->dwVpos  = new->dwVpos;
                     applyEvent(joystick, event);
                     return true;
                 }
-                else if ((new->dwFlags & JOY_RETURNBUTTONS) && cur->dwButtons != new->dwButtons)
+                else if ((new->dwFlags& JOY_RETURNBUTTONS) && cur->dwButtons != new->dwButtons)
                 {
                     DWORD change = cur->dwButtons ^ new->dwButtons;
                     if (change != 0)
                     {
                         uint32_t buttonIdx = __builtin_ctz(change);
 
-                        event->type = BUTTON;
+                        event->type   = BUTTON;
                         event->button = buttonIdx;
 
                         if (new->dwButtons & (1 << buttonIdx))
@@ -403,7 +375,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                         return true;
                     }
                 }
-                else if ((new->dwFlags & JOY_RETURNPOV) && cur->dwPOV != new->dwPOV)
+                else if ((new->dwFlags& JOY_RETURNPOV) && cur->dwPOV != new->dwPOV)
                 {
                     // This is kinda weird!
                     // This is because we're splitting a single POV hat event into two discrete axes
@@ -441,7 +413,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                         }
 
                         winData->pendingPov = false;
-                        cur->dwPOV = new->dwPOV;
+                        cur->dwPOV          = new->dwPOV;
                     }
 
                     applyEvent(joystick, event);
@@ -459,7 +431,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
 #elif defined(EMU_LINUX)
         struct js_event linuxEvent;
 
-        errno = 0;
+        errno     = 0;
         int count = read((int)joystick->data, &linuxEvent, sizeof(struct js_event));
         if (count >= (int)sizeof(struct js_event))
         {
@@ -467,16 +439,16 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
             {
                 case JS_EVENT_BUTTON:
                 {
-                    event->type = BUTTON;
+                    event->type   = BUTTON;
                     event->button = linuxEvent.number;
-                    event->value = linuxEvent.value;
+                    event->value  = linuxEvent.value;
                     break;
                 }
 
                 case JS_EVENT_AXIS:
                 {
-                    event->type = AXIS;
-                    event->axis = linuxEvent.number;
+                    event->type  = AXIS;
+                    event->axis  = linuxEvent.number;
                     event->value = linuxEvent.value;
                     break;
                 }
@@ -507,7 +479,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                 free(joystick->buttonData);
                 joystick->buttonData = NULL;
             }
-            
+
             close((int)joystick->data);
             joystick->data = NULL;
             return false;
@@ -527,7 +499,8 @@ bool gamepadInitCb(emuArgs_t* args)
 {
     if (gamepadConnect(&joystickExt))
     {
-        ESP_LOGI("GamepadExt", "Connected to joystick with %d axes and %d buttons\n", joystickExt.numAxes, joystickExt.numButtons);
+        ESP_LOGI("GamepadExt", "Connected to joystick with %d axes and %d buttons\n", joystickExt.numAxes,
+                 joystickExt.numButtons);
         return true;
     }
 
@@ -556,7 +529,7 @@ void gamepadPreFrameCb(uint64_t frame)
             }
 
             case AXIS:
-            {   
+            {
                 switch (event.axis)
                 {
                     case TOUCH_AXIS_X:
@@ -575,10 +548,10 @@ void gamepadPreFrameCb(uint64_t frame)
                         else
                         {
                             const double maxRadius = 1024;
-                            
-                            double angle = atan2(-y, x);
+
+                            double angle        = atan2(-y, x);
                             double angleDegrees = (angle * 180) / M_PI;
-                            int radius = CLAMP(sqrt(x * x + y * y) * maxRadius / 32768, 0, maxRadius);
+                            int radius          = CLAMP(sqrt(x * x + y * y) * maxRadius / 32768, 0, maxRadius);
 
                             int angleDegreesRounded = (int)(angleDegrees + 360) % 360;
                             emulatorSetTouchJoystick(CLAMP(angleDegreesRounded, 0, 359), radius, 1024);
@@ -621,7 +594,7 @@ void gamepadPreFrameCb(uint64_t frame)
                         }
 
                         buttonBit_t lastState = emulatorGetButtonState();
-                        buttonBit_t changes = (lastState ^ curState) & ((1 << 8) - 1);
+                        buttonBit_t changes   = (lastState ^ curState) & ((1 << 8) - 1);
 
                         if (changes & PB_UP)
                         {

--- a/emulator/src/extensions/gamepad/ext_gamepad.h
+++ b/emulator/src/extensions/gamepad/ext_gamepad.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "emu_ext.h"
+
+extern emuExtension_t gamepadEmuExtension;


### PR DESCRIPTION
### Description

Joystick inputs! They work on Windows and Linux, I haven't attempted OSX at all.

On both platforms, the joystick must be connected before the emulator starts. If the joystick is disconnected, the emulator will not attempt to reconnect to it.

Also in support of arcade-y things, I fixed the emulator display not being centered properly in fullscreen and some other situations that come up more often now that the LEDs have moved.

### Test Instructions

It's more or less plug and play! On Windows, will open the first joystick device available. On Linux, will open `/dev/input/js0`.

1. Plug in a swadge to USB
2. Open up Gamepad mode and start in Computer mode
3. Start the emulator
4. It should Just Work!
5. Try the Touch Test and Accel Test modes, and also everything else.
6. Open the emulator in fullscreen

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
