### PR TITLE
More Console Commands and Replay Script Support

### DIFF
--- a/docs/EMULATOR.md
+++ b/docs/EMULATOR.md
@@ -137,6 +137,7 @@ and touchpad inputs will be written to the recording file, in addition to:
 * The original random number generator seed (on playback, this is equivalent to passing `--seed`).
 * A screenshot event, whenever a screenshot is taken. Note that the filename is not included, so that the original
   screenshot is not overwritten on playback.
+* Any console commands issued
 
 `--playback`: Play back inputs from a recording file, the name of which must be given as an argument. While
 inputs are being played back, the emulator will still also accept input directly.
@@ -162,11 +163,11 @@ A recording file is a CSV (comma-separated value) file with three columns: Time,
 | Screenshot     | Screenshot filename   | Take a screenshot, using a default filename if none is given |
 | SetMode        | Mode name             | Switch swadge modes to the named mode                        |
 | Seed           | Seed value            | Set the PRNG seed. This should be the first entry in a file  |
-| RecordingStart | Recording filename    | Start recording the screen to a GIF, using a default filename if none is given |
-| RecordingStop  | -                     | Stop recording the screen                                    |
+| Command        | Console command       | Execute an arbitrary console command                         |
 
 Note that the `Fuzz`, `Quit`, and `SetMode` entries are never created during recording, and are instead
-intended to be inserted manually if desired.
+intended to be inserted manually if desired. The `Command` entry can contain any valid
+[console command](#console-commands).
 
 **Button Values**
 
@@ -184,7 +185,8 @@ intended to be inserted manually if desired.
 ### Fuzzing
 
 These options are for the "fuzzing" functionality, which can help find bugs in modes by generating random
-inputs. This includes random
+inputs. This includes random button presses, touchpad inputs, accelerometer motion, and even random frame
+timing changes.
 
 `--fuzz`: Enables fuzzing mode. The default fuzzing behavior is to fuzz button presses, touchpad inputs, and
 accelerometer motion, but these can individually be enabled with `--fuzz-*` arguments. Fuzzing the length
@@ -242,6 +244,31 @@ from one system will not necessarily produce the same output if it is used on a 
 
 `--keymap`: Specify an alternative keyboard layout to use for mapping emulator inputs. Possible options
 are `azerty`, `dvorak`, or `colemak`.
+
+## Console Commands
+
+The emulator supports a small number of commands in the console, which can be opened by pressing `F4` or
+the `\`` / `~` key. These console commands can also be used from a [replay script](#recording-and-playing-inputs).
+To get a complete list of available commands, type `help` into the console. For the usage of a specific command,
+type `help <command>` into the console.
+
+| Command                  | Description
+|--------------------------|-------------------------------------------------------------------------------------------------------|
+| `help [command]`         | Prints a list of commands, or detailed help for a specific command                                    |
+| `screenshot [filename]`  | Saves a screenshot to `filename`, or to a timestamp-based file name if no filename is given           |
+| `mode <mode-name>`       | Immediately switches the Swadge to the mode named `mode-name`                                         |
+| `gif [filename]`         | Starts recording a GIF to `filename` (or a timestamp-based file name), or stops the current recording |
+| `replay <filename>`      | Starts playing back inputs from `filename`. Stops any current playing back or recording of inputs.    |
+| `record [filename]`      | Starts recording inputs to `filename`, or to a timestamp-based file name if no filename is given      |
+| `fuzz [on|off]`          | Toggles fuzzing on or off                                                                             |
+| `fuzz buttons [on|off]`  | Toggles fuzzing of button presses on or off                                                           |
+| `fuzz buttons mask <...>`| Sets the buttons that will be used when fuzzing, separated by spaces, e.g. `fuzz buttons mask up down left right` |
+| `fuzz buttons mask`      | Prints the buttons that will be used when fuzzing                                                     |
+| `fuzz touch [on|off]`    | Toggles fuzzing of touchpad inputs on or off                                                          |
+| `fuzz motion [on|off]`   | Toggles fuzzing of accelerometer motion on or off                                                     |
+| `fuzz time [on|off]`     | Toggles fuzzing of frame timings on or off                                                            |
+| `touchpad [on|off]`      | Toggles the emulator's virtual touchpad on or off                                                     |
+| `leds [on|off]`          | Toggles the emulator's virtual LEDs on or off                                                         |
 
 ## Troubleshooting
 

--- a/emulator/src/extensions/emu_ext.c
+++ b/emulator/src/extensions/emu_ext.c
@@ -347,6 +347,8 @@ int requestPane(const emuExtension_t* ext, paneLocation_t loc, uint32_t minW, ui
         paneInfo->pane.id      = extInfo->panes.length;
 
         push(&extInfo->panes, paneInfo);
+        extManager.paneMinsCalculated = false;
+
         return paneInfo->pane.id;
     }
     return -1;

--- a/emulator/src/extensions/fuzzer/ext_fuzzer.c
+++ b/emulator/src/extensions/fuzzer/ext_fuzzer.c
@@ -29,6 +29,8 @@ typedef struct
     bool touch;
     bool motion;
     bool time;
+
+    buttonBit_t buttonMask;
 } fuzzer_t;
 
 //==============================================================================
@@ -60,6 +62,8 @@ static bool fuzzerInitCb(emuArgs_t* emuArgs)
     fuzzer.motion  = emuArgs->fuzzMotion;
     fuzzer.time    = emuArgs->fuzzTime;
 
+    fuzzer.buttonMask = (PB_A | PB_B | PB_UP | PB_DOWN | PB_LEFT | PB_RIGHT | PB_START);
+
     if (emuArgs->fuzz)
     {
         printf("\nFuzzing:\n - [%c] Buttons\n - [%c] Touch\n - [%c] Motion\n - [%c] Time\n", fuzzer.buttons ? 'X' : ' ',
@@ -84,8 +88,11 @@ static void fuzzerPreFrameCb(uint64_t frame)
         uint8_t i              = rand() % 8;
         buttonBit_t fuzzButton = (1 << i);
 
-        // Inject the button event to flip that button's state
-        emulatorInjectButton(fuzzButton, (buttonState & fuzzButton) == 0);
+        if (fuzzButton & fuzzer.buttonMask)
+        {
+            // Inject the button event to flip that button's state
+            emulatorInjectButton(fuzzButton, (buttonState & fuzzButton) == 0);
+        }
     }
 
     if (fuzzer.touch)
@@ -128,4 +135,54 @@ static void fuzzerPreFrameCb(uint64_t frame)
         fakeTime += (rand() % 128) * 1000 << (rand() % (4));
         emuSetEspTimerTime(fakeTime);
     }
+}
+
+void emuSetFuzzButtonsEnabled(bool enabled)
+{
+    fuzzer.buttons = enabled;
+}
+
+bool emuGetFuzzButtonsEnabled(void)
+{
+    return fuzzer.buttons;
+}
+
+void emuSetFuzzTouchEnabled(bool enabled)
+{
+    fuzzer.touch = enabled;
+}
+
+bool emuGetFuzzTouchEnabled(void)
+{
+    return fuzzer.touch;
+}
+
+void emuSetFuzzMotionEnabled(bool enabled)
+{
+    fuzzer.motion = enabled;
+}
+
+bool emuGetFuzzMotionEnabled(void)
+{
+    return fuzzer.motion;
+}
+
+void emuSetFuzzTimeEnabled(bool enabled)
+{
+    fuzzer.time = enabled;
+}
+
+bool emuGetFuzzTimeEnabled(void)
+{
+    return fuzzer.time;
+}
+
+void emuSetFuzzButtonsMask(buttonBit_t mask)
+{
+    fuzzer.buttonMask = mask;
+}
+
+buttonBit_t emuGetFuzzButtonsMask(void)
+{
+    return fuzzer.buttonMask;
 }

--- a/emulator/src/extensions/fuzzer/ext_fuzzer.h
+++ b/emulator/src/extensions/fuzzer/ext_fuzzer.h
@@ -1,5 +1,18 @@
 #pragma once
 
 #include "emu_ext.h"
+#include "hdw-btn.h"
 
 extern emuExtension_t fuzzerEmuExtension;
+
+void emuSetFuzzButtonsEnabled(bool enabled);
+bool emuGetFuzzButtonsEnabled(void);
+void emuSetFuzzTouchEnabled(bool enabled);
+bool emuGetFuzzTouchEnabled(void);
+void emuSetFuzzMotionEnabled(bool enabled);
+bool emuGetFuzzMotionEnabled(void);
+void emuSetFuzzTimeEnabled(bool enabled);
+bool emuGetFuzzTimeEnabled(void);
+
+void emuSetFuzzButtonsMask(buttonBit_t mask);
+buttonBit_t emuGetFuzzButtonsMask(void);

--- a/emulator/src/extensions/replay/ext_replay.c
+++ b/emulator/src/extensions/replay/ext_replay.c
@@ -956,14 +956,13 @@ void emulatorRecordCommand(const char* command)
             .commandStr = NULL,
         };
 
-        if (!strncmp("record", command, strlen("record")))
-        {
-            // Don't insert recording-related commands into the recording
-            return;
-        }
-
         if (command)
         {
+            if (!strncmp("record", command, strlen("record")))
+            {
+                // Don't insert recording-related commands into the recording
+                return;
+            }
             // Create a copy of the filename since entry.commandStr is not const
             char tmp[strlen(command) + 1];
             strcpy(tmp, command);

--- a/emulator/src/extensions/replay/ext_replay.h
+++ b/emulator/src/extensions/replay/ext_replay.h
@@ -69,6 +69,9 @@
 extern emuExtension_t replayEmuExtension;
 
 void startRecording(const char* recordingName);
+void stopRecording(void);
+bool isRecordingInput(void);
 void startPlayback(const char* recordingName);
 void recordScreenshotTaken(const char* name);
 void emulatorRecordRandomSeed(uint32_t seed);
+void emulatorRecordCommand(const char* command);

--- a/emulator/src/extensions/tools/emu_console_cmds.c
+++ b/emulator/src/extensions/tools/emu_console_cmds.c
@@ -465,11 +465,11 @@ static int injectCommandCb(const char** args, int argCount, char* out)
             return 0;
         }
 
-        char* typeArg   = args[3];
-        char* keyArg    = args[2];
-        char** valueArg = NULL;
+        const char* typeArg   = args[3];
+        const char* keyArg    = args[2];
+        const char** valueArg = NULL;
 
-        char* namespace = "storage";
+        const char* namespace = "storage";
 
         if (!strcmp(typeArg, "int") || !strcmp(typeArg, "str") || !strcmp(typeArg, "file"))
         {
@@ -521,7 +521,7 @@ static int injectCommandCb(const char** args, int argCount, char* out)
             }
             else
             {
-                for (char** argPtr = valueArg; argPtr < (args + argCount); argPtr++)
+                for (const char** argPtr = valueArg; argPtr < (args + argCount); argPtr++)
                 {
                     if (argPtr > valueArg)
                     {
@@ -645,7 +645,7 @@ static int helpCommandCb(const char** args, int argCount, char* out)
         int matches = 0;
         for (int i = 0; i < (sizeof(commandDocs) / sizeof(commandDocs[0])); i++)
         {
-            char** doc = commandDocs[i];
+            const char** doc = commandDocs[i];
 
             if (!strncasecmp(cmdMatchBuf, doc[0], strlen(cmdMatchBuf)))
             {

--- a/emulator/src/extensions/tools/emu_console_cmds.c
+++ b/emulator/src/extensions/tools/emu_console_cmds.c
@@ -5,20 +5,49 @@
 #include "ext_tools.h"
 #include "emu_utils.h"
 #include "ext_replay.h"
+#include "ext_fuzzer.h"
 
 // Console command handlers
 static int screenshotCommandCb(const char** args, int argCount, char* out);
+static int screenRecordCommandCb(const char** args, int argCount, char* out);
 static int setModeCommandCb(const char** args, int argCount, char* out);
 static int recordCommandCb(const char** args, int argCount, char* out);
 static int replayCommandCb(const char** args, int argCount, char* out);
+static int fuzzCommandCb(const char** args, int argCount, char* out);
+static int touchCommandCb(const char** args, int argCount, char* out);
 static int helpCommandCb(const char** args, int argCount, char* out);
 
+static const char* buttonNames[] = {
+    "Up", "Down", "Left", "Right", "A", "B", "Start", "Select",
+};
+
+// command, usage, description
+// just a simple way to document sub-commands, etc.
+static const char* commandDocs[][3] = {
+    {"screenshot", "screenshot [filename]",
+     "saves a screenshot to [filename], or an auto-generated file name if not specified"},
+    {"gif", "gif [filename]",
+     "starts or stops recording the screen to a GIF named [filename], or an auto-generated file name if not specified"},
+    {"mode", "mode [name]", "immediately changes the mode to [name], or lists all mode names if not specified"},
+    {"replay", "replay [filename]", "open and replay recorded inputs from replay file [filename]"},
+    {"record", "record [name]",
+     "begin recording inputs into replay file [filename], or an auto-generated file name if not specified"},
+    {"fuzz", "fuzz [on|off]", "toggles the fuzzer"},
+    {"fuzz buttons", "fuzz buttons [on|off]", "toggles fuzzing of button inputs"},
+    {"fuzz buttons mask", "fuzz buttons mask [<button>[ <button>  ...]]",
+     "sets or prints which buttons will be fuzzed\n    Valid options: Up, Down, Left, Right, A, B, Start, or Select"},
+    {"fuzz touch", "fuzz touch [on|off]", "toggles fuzzing of touchpad inputs"},
+    {"fuzz motion", "fuzz motion [on|off]", "toggles fuzzing of accelerometer motion inputs"},
+    {"fuzz time", "fuzz time [on|off]", "toggles fuzzing of frame times"},
+    {"touch", "touch [on|off]", "toggles the virtual touchpad"},
+    {"help", "help [command]", "prints help text for all commands, or for commands matching [command]"},
+};
+
 static const consoleCommand_t consoleCommands[] = {
-    {.name = "screenshot", .cb = screenshotCommandCb},
-    {.name = "mode", .cb = setModeCommandCb},
-    {.name = "record", .cb = recordCommandCb},
-    {.name = "replay", .cb = replayCommandCb},
-    {.name = "help", .cb = helpCommandCb},
+    {.name = "screenshot", .cb = screenshotCommandCb}, {.name = "mode", .cb = setModeCommandCb},
+    {.name = "gif", .cb = screenRecordCommandCb},      {.name = "replay", .cb = replayCommandCb},
+    {.name = "record", .cb = recordCommandCb},         {.name = "fuzz", .cb = fuzzCommandCb},
+    {.name = "touch", .cb = touchCommandCb},           {.name = "help", .cb = helpCommandCb},
 };
 
 const consoleCommand_t* getConsoleCommands(void)
@@ -79,14 +108,14 @@ static int setModeCommandCb(const char** args, int argCount, char* out)
     }
 }
 
-static int recordCommandCb(const char** args, int argCount, char* out)
+static int screenRecordCommandCb(const char** args, int argCount, char* out)
 {
     const char* name = NULL;
 
     if (isScreenRecording())
     {
         stopScreenRecording();
-        return sprintf(out, "Recording finished");
+        return sprintf(out, "GIF Recording finished\n");
     }
     else
     {
@@ -95,25 +124,330 @@ static int recordCommandCb(const char** args, int argCount, char* out)
             name = args[0];
         }
 
-        startRecording(name);
-        return sprintf(out, "Recording started");
+        startScreenRecording(name);
+        return sprintf(out, "GIF Recording started\n");
     }
 }
 
 static int replayCommandCb(const char** args, int argCount, char* out)
 {
-    return sprintf(out, "Playback started");
+    if (argCount > 0)
+    {
+        startPlayback(args[1]);
+        return sprintf(out, "Playback started\n");
+    }
+    else
+    {
+        return sprintf(out, "Filename is required!\n");
+    }
+}
+
+static int recordCommandCb(const char** args, int argCount, char* out)
+{
+    if (argCount > 0)
+    {
+        startRecording(args[0]);
+        return sprintf(out, "Input recording started\n");
+    }
+    else
+    {
+        if (isRecordingInput())
+        {
+            stopRecording();
+            return sprintf(out, "Input recording stopped\n");
+        }
+        else
+        {
+            startRecording(NULL);
+            return sprintf(out, "Input recording started\n");
+        }
+    }
+}
+
+static int fuzzCommandCb(const char** args, int argCount, char* out)
+{
+    if (argCount > 0)
+    {
+        // on
+        // off
+        // buttons (toggle)
+        // touch (toggle)
+        // motion (toggle)
+
+        if (!strncmp("on", args[0], strlen(args[0])))
+        {
+            // fuzz on
+            if (!emulatorArgs.fuzz)
+            {
+                emulatorArgs.fuzz        = true;
+                emulatorArgs.fuzzButtons = emuGetFuzzButtonsEnabled();
+                emulatorArgs.fuzzMotion  = emuGetFuzzMotionEnabled();
+                emulatorArgs.fuzzTouch   = emuGetFuzzTouchEnabled();
+                emulatorArgs.fuzzTime    = emuGetFuzzTimeEnabled();
+                enableExtension("fuzzer");
+
+                return sprintf(out, "Fuzzer enabled\n");
+            }
+        }
+        else if (!strncmp("off", args[0], strlen(args[0])))
+        {
+            // fuzz off
+            if (emulatorArgs.fuzz)
+            {
+                emulatorArgs.fuzz = false;
+                disableExtension("fuzzer");
+
+                return sprintf(out, "Fuzzer disabled\n");
+            }
+        }
+        else if (!strncmp("buttons", args[0], strlen(args[0])))
+        {
+            if (argCount > 1)
+            {
+                // fuzz buttons ...
+                if (!strncmp("on", args[1], strlen(args[1])))
+                {
+                    // fuzz buttons on
+                    emuSetFuzzButtonsEnabled(true);
+
+                    return sprintf(out, "Fuzzing buttons enabled\n");
+                }
+                else if (!strncmp("off", args[1], strlen(args[1])))
+                {
+                    // fuzz buttons off
+                    emuSetFuzzButtonsEnabled(false);
+
+                    return sprintf(out, "Fuzzing buttons disabled\n");
+                }
+                else if (!strncmp("mask", args[1], strlen(args[1])))
+                {
+                    // Set mask (fuzz buttons mask up down left right a b start select)
+                    if (argCount > 2)
+                    {
+                        // fuzz buttons mask ...
+                        buttonBit_t mask = 0;
+                        for (int argNum = 2; argNum < argCount; argNum++)
+                        {
+                            for (int i = 0; i < 8; i++)
+                            {
+                                buttonBit_t btn        = (buttonBit_t)(1 << i);
+                                const char* buttonName = buttonNames[i];
+
+                                if (!strcasecmp(buttonName, args[argNum]))
+                                {
+                                    mask |= btn;
+                                    break;
+                                }
+                            }
+                        }
+                        emuSetFuzzButtonsMask(mask);
+                    }
+
+                    // fuzz buttons mask[ ...]
+
+                    // Print mask, regardless of whether it was just changed
+                    // this is part of the code path for both "fuzz buttons mask" and e.g. "fuzz buttons mask a b up"
+                    int written = 0;
+                    written += sprintf(out + written, "Fuzzing buttons:\n");
+
+                    buttonBit_t mask = emuGetFuzzButtonsMask();
+
+                    for (int i = 0; i < 8; i++)
+                    {
+                        buttonBit_t btn = (buttonBit_t)(1 << i);
+
+                        if (mask & btn)
+                        {
+                            written += sprintf(out + written, "- %s\n", buttonNames[i]);
+                        }
+                    }
+
+                    return written;
+                }
+            }
+            else
+            {
+                emuSetFuzzButtonsEnabled(!emuGetFuzzButtonsEnabled());
+
+                return sprintf(out, "Fuzzing buttons %s\n", emuGetFuzzButtonsEnabled() ? "enabled" : "disabled");
+            }
+        }
+        else if (!strncmp("touch", args[0], strlen(args[0])))
+        {
+            if (argCount > 1)
+            {
+                if (!strncmp("on", args[1], strlen(args[1])))
+                {
+                    emuSetFuzzTouchEnabled(true);
+                    return sprintf(out, "Fuzzing touch enabled\n");
+                }
+                else if (!strncmp("off", args[1], strlen(args[1])))
+                {
+                    emuSetFuzzTouchEnabled(false);
+                    return sprintf(out, "Fuzzing touch disabled\n");
+                }
+            }
+            else
+            {
+                emuSetFuzzTouchEnabled(!emuGetFuzzTouchEnabled());
+
+                return sprintf(out, "Fuzzing touch %s\n", emuGetFuzzTouchEnabled() ? "enabled" : "disabled");
+            }
+        }
+        else if (!strncmp("motion", args[0], strlen(args[0])))
+        {
+            if (argCount > 1)
+            {
+                if (!strncmp("on", args[1], strlen(args[1])))
+                {
+                    emuSetFuzzMotionEnabled(true);
+                    return sprintf(out, "Fuzzing motion enabled\n");
+                }
+                else if (!strncmp("off", args[1], strlen(args[1])))
+                {
+                    emuSetFuzzMotionEnabled(false);
+                    return sprintf(out, "Fuzzing motion disabled\n");
+                }
+            }
+            else
+            {
+                emuSetFuzzMotionEnabled(!emuGetFuzzMotionEnabled());
+
+                return sprintf(out, "Fuzzing motion %s\n", emuGetFuzzMotionEnabled() ? "enabled" : "disabled");
+            }
+        }
+        else if (!strncmp("time", args[0], strlen(args[0])))
+        {
+            if (argCount > 1)
+            {
+                if (!strncmp("on", args[1], strlen(args[1])))
+                {
+                    emuSetFuzzTimeEnabled(true);
+                    return sprintf(out, "Fuzzing time enabled\n");
+                }
+                else if (!strncmp("off", args[1], strlen(args[1])))
+                {
+                    emuSetFuzzTimeEnabled(false);
+                    return sprintf(out, "Fuzzing time disabled\n");
+                }
+            }
+        }
+    }
+    else
+    {
+        // Toggle fuzzing on/off
+        if (emulatorArgs.fuzz)
+        {
+            emulatorArgs.fuzz = false;
+            disableExtension("fuzzer");
+
+            return sprintf(out, "Fuzzer disabled\n");
+        }
+        else
+        {
+            emulatorArgs.fuzz        = true;
+            emulatorArgs.fuzzButtons = emuGetFuzzButtonsEnabled();
+            emulatorArgs.fuzzMotion  = emuGetFuzzMotionEnabled();
+            emulatorArgs.fuzzTouch   = emuGetFuzzTouchEnabled();
+            emulatorArgs.fuzzTime    = emuGetFuzzTimeEnabled();
+            enableExtension("fuzzer");
+
+            return sprintf(out, "Fuzzer enabled\n");
+        }
+    }
+
+    return 0;
+}
+
+static int touchCommandCb(const char** args, int argCount, char* out)
+{
+    bool enable = false;
+    if (argCount > 0)
+    {
+        if (!strncmp("on", args[0], strlen(args[0])))
+        {
+            enable = true;
+        }
+        else if (!strncmp("off", args[0], strlen(args[0])))
+        {
+            enable = false;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+    else
+    {
+        enable = !emulatorArgs.emulateTouch;
+    }
+
+    if (enable)
+    {
+        if (!emulatorArgs.emulateTouch)
+        {
+            // It needs to be reset
+            disableExtension("touch");
+        }
+        emulatorArgs.emulateTouch = true;
+        enableExtension("touch");
+    }
+    else
+    {
+        emulatorArgs.emulateTouch = false;
+        disableExtension("touch");
+    }
+    return sprintf(out, "Touchpad %s\n", enable ? "enabled" : "disabled");
 }
 
 static int helpCommandCb(const char** args, int argCount, char* out)
 {
     char* cur = out;
 
-    cur += snprintf(cur, 1024, "Available Commands:\n");
-    for (const consoleCommand_t* action = consoleCommands; action < (consoleCommands + ARRAY_SIZE(consoleCommands));
-         action++)
+    if (argCount > 0)
     {
-        cur += snprintf(cur, 1024 - (cur - out), "- %s\n", action->name);
+        char cmdMatchBuf[512];
+        char* bufOut = cmdMatchBuf;
+        for (int i = 0; i < argCount; i++)
+        {
+            if (i > 0)
+            {
+                bufOut += snprintf(bufOut, sizeof(cmdMatchBuf) - (bufOut - cmdMatchBuf), " %s", args[i]);
+            }
+            else
+            {
+                bufOut += snprintf(bufOut, sizeof(cmdMatchBuf) - (bufOut - cmdMatchBuf), "%s", args[i]);
+            }
+        }
+
+        printf("Looking for %s...\n", cmdMatchBuf);
+
+        int matches = 0;
+        for (int i = 0; i < (sizeof(commandDocs) / sizeof(commandDocs[0])); i++)
+        {
+            char** doc = commandDocs[i];
+
+            if (!strncasecmp(cmdMatchBuf, doc[0], strlen(cmdMatchBuf)))
+            {
+                matches++;
+                cur += snprintf(cur, 1024 - (cur - out), "- %s    ---- %s\n", doc[1], doc[2]);
+            }
+        }
+
+        if (!matches)
+        {
+            cur += snprintf(cur, 1024 - (cur - out), "No matching commands found!\n");
+        }
+    }
+    else
+    {
+        cur += snprintf(cur, 1024, "Available Commands:\n");
+        for (const consoleCommand_t* action = consoleCommands; action < (consoleCommands + ARRAY_SIZE(consoleCommands));
+             action++)
+        {
+            cur += snprintf(cur, 1024 - (cur - out), "- %s\n", action->name);
+        }
+        cur += snprintf(cur, 1024 - (cur - out), "Type 'help <command>' for more information\n");
     }
 
     return (cur - out);

--- a/emulator/src/extensions/tools/emu_console_cmds.c
+++ b/emulator/src/extensions/tools/emu_console_cmds.c
@@ -47,22 +47,18 @@ static const char* commandDocs[][3] = {
     {"fuzz time", "fuzz time [on|off]", "toggles fuzzing of frame times"},
     {"touchpad", "touchpad [on|off]", "toggles the virtual touchpad"},
     {"inject", "inject <nvs|asset> <...>", "injects data into NVS or assets"},
-    {"inject nvs", "inject nvs [namespace] <key> <int|str|file> <value>", "injects data into an NVS key. Value can be either an integer, a string, or a file path"},
+    {"inject nvs", "inject nvs [namespace] <key> <int|str|file> <value>",
+     "injects data into an NVS key. Value can be either an integer, a string, or a file path"},
     {"inject asset", "inject asset <name> <filename>", "injects a file's entire contents as an asset"},
     {"help", "help [command]", "prints help text for all commands, or for commands matching [command]"},
 };
 
 static const consoleCommand_t consoleCommands[] = {
-    {.name = "screenshot", .cb = screenshotCommandCb},
-    {.name = "mode", .cb = setModeCommandCb},
-    {.name = "gif", .cb = screenRecordCommandCb},
-    {.name = "replay", .cb = replayCommandCb},
-    {.name = "record", .cb = recordCommandCb},
-    {.name = "fuzz", .cb = fuzzCommandCb},
-    {.name = "touchpad", .cb = touchCommandCb},
-    {.name = "leds", .cb = ledsCommandCb},
-    {.name = "inject", .cb = injectCommandCb},
-    {.name = "help", .cb = helpCommandCb},
+    {.name = "screenshot", .cb = screenshotCommandCb}, {.name = "mode", .cb = setModeCommandCb},
+    {.name = "gif", .cb = screenRecordCommandCb},      {.name = "replay", .cb = replayCommandCb},
+    {.name = "record", .cb = recordCommandCb},         {.name = "fuzz", .cb = fuzzCommandCb},
+    {.name = "touchpad", .cb = touchCommandCb},        {.name = "leds", .cb = ledsCommandCb},
+    {.name = "inject", .cb = injectCommandCb},         {.name = "help", .cb = helpCommandCb},
 };
 
 const consoleCommand_t* getConsoleCommands(void)
@@ -469,8 +465,8 @@ static int injectCommandCb(const char** args, int argCount, char* out)
             return 0;
         }
 
-        char* typeArg = args[3];
-        char* keyArg = args[2];
+        char* typeArg   = args[3];
+        char* keyArg    = args[2];
         char** valueArg = NULL;
 
         char* namespace = "storage";
@@ -486,7 +482,7 @@ static int injectCommandCb(const char** args, int argCount, char* out)
         else
         {
             typeArg = args[2];
-            keyArg = args[1];
+            keyArg  = args[1];
 
             if (argCount > 3)
             {
@@ -501,8 +497,8 @@ static int injectCommandCb(const char** args, int argCount, char* out)
                 return snprintf(out, 1024, "Value is required\n");
             }
 
-            char* endPtr = NULL;
-            errno = 0;
+            char* endPtr   = NULL;
+            errno          = 0;
             int32_t intVal = strtol(*valueArg, &endPtr, 10);
             if (errno != 0)
             {
@@ -553,7 +549,7 @@ static int injectCommandCb(const char** args, int argCount, char* out)
             expandPath(filenameBuf, sizeof(filenameBuf), *valueArg);
 
             FILE* file = NULL;
-            file = fopen(filenameBuf, "rb");
+            file       = fopen(filenameBuf, "rb");
             if (NULL != file)
             {
                 fseek(file, 0, SEEK_END);
@@ -583,7 +579,8 @@ static int injectCommandCb(const char** args, int argCount, char* out)
 
                     free(fileData);
 
-                    return snprintf(out, 1024, "Set NVS %s:%s to content of file '%s'\n", namespace, keyArg, filenameBuf);
+                    return snprintf(out, 1024, "Set NVS %s:%s to content of file '%s'\n", namespace, keyArg,
+                                    filenameBuf);
                 }
                 fclose(file);
             }
@@ -602,7 +599,6 @@ static int injectCommandCb(const char** args, int argCount, char* out)
         {
             char filenameBuf[1024];
             expandPath(filenameBuf, sizeof(filenameBuf), args[2]);
-
 
             if (emuCnfsInjectFile(args[1], filenameBuf))
             {

--- a/emulator/src/extensions/tools/emu_console_cmds.c
+++ b/emulator/src/extensions/tools/emu_console_cmds.c
@@ -15,6 +15,7 @@ static int recordCommandCb(const char** args, int argCount, char* out);
 static int replayCommandCb(const char** args, int argCount, char* out);
 static int fuzzCommandCb(const char** args, int argCount, char* out);
 static int touchCommandCb(const char** args, int argCount, char* out);
+static int ledsCommandCb(const char** args, int argCount, char* out);
 static int helpCommandCb(const char** args, int argCount, char* out);
 
 static const char* buttonNames[] = {
@@ -39,15 +40,20 @@ static const char* commandDocs[][3] = {
     {"fuzz touch", "fuzz touch [on|off]", "toggles fuzzing of touchpad inputs"},
     {"fuzz motion", "fuzz motion [on|off]", "toggles fuzzing of accelerometer motion inputs"},
     {"fuzz time", "fuzz time [on|off]", "toggles fuzzing of frame times"},
-    {"touch", "touch [on|off]", "toggles the virtual touchpad"},
+    {"touchpad", "touchpad [on|off]", "toggles the virtual touchpad"},
     {"help", "help [command]", "prints help text for all commands, or for commands matching [command]"},
 };
 
 static const consoleCommand_t consoleCommands[] = {
-    {.name = "screenshot", .cb = screenshotCommandCb}, {.name = "mode", .cb = setModeCommandCb},
-    {.name = "gif", .cb = screenRecordCommandCb},      {.name = "replay", .cb = replayCommandCb},
-    {.name = "record", .cb = recordCommandCb},         {.name = "fuzz", .cb = fuzzCommandCb},
-    {.name = "touch", .cb = touchCommandCb},           {.name = "help", .cb = helpCommandCb},
+    {.name = "screenshot", .cb = screenshotCommandCb},
+    {.name = "mode", .cb = setModeCommandCb},
+    {.name = "gif", .cb = screenRecordCommandCb},
+    {.name = "replay", .cb = replayCommandCb},
+    {.name = "record", .cb = recordCommandCb},
+    {.name = "fuzz", .cb = fuzzCommandCb},
+    {.name = "touchpad", .cb = touchCommandCb},
+    {.name = "leds", .cb = ledsCommandCb},
+    {.name = "help", .cb = helpCommandCb},
 };
 
 const consoleCommand_t* getConsoleCommands(void)
@@ -398,6 +404,42 @@ static int touchCommandCb(const char** args, int argCount, char* out)
         disableExtension("touch");
     }
     return sprintf(out, "Touchpad %s\n", enable ? "enabled" : "disabled");
+}
+
+static int ledsCommandCb(const char** args, int argCount, char* out)
+{
+    bool enable = false;
+    if (argCount > 0)
+    {
+        if (!strncmp("on", args[0], strlen(args[0])))
+        {
+            enable = true;
+        }
+        else if (!strncmp("off", args[0], strlen(args[0])))
+        {
+            enable = false;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+    else
+    {
+        enable = emulatorArgs.hideLeds;
+    }
+
+    if (enable)
+    {
+        emulatorArgs.hideLeds = false;
+        enableExtension("leds");
+    }
+    else
+    {
+        emulatorArgs.hideLeds = true;
+        disableExtension("leds");
+    }
+    return sprintf(out, "LEDs %s\n", enable ? "enabled" : "disabled");
 }
 
 static int helpCommandCb(const char** args, int argCount, char* out)

--- a/emulator/src/extensions/tools/ext_tools.c
+++ b/emulator/src/extensions/tools/ext_tools.c
@@ -52,7 +52,6 @@ static int32_t toolsKeyCb(uint32_t keycode, bool down, modKey_t modifiers);
 static void toolsPreFrame(uint64_t frame);
 static void toolsPostFrame(uint64_t frame);
 static void toolsRenderCb(uint32_t winW, uint32_t winH, const emuPane_t* panes, uint8_t numPanes);
-static void handleConsoleCommand(const char* command);
 static void makeTransparent(uint8_t* framebuffer);
 
 static const char* getScreenshotName(char* buffer, size_t maxlen);
@@ -97,7 +96,7 @@ static int consolePaneId        = -1;
 static char consoleBuffer[1024] = {0};
 static char* consolePtr         = consoleBuffer;
 
-static char consoleOutput[1024] = {0};
+static char consoleOutput[2048] = {0};
 
 //==============================================================================
 // Functions
@@ -151,6 +150,7 @@ static int32_t toolsKeyCb(uint32_t keycode, bool down, modKey_t modifiers)
             else if (keycode == CNFG_KEY_ENTER)
             {
                 // Handle console command
+                emulatorRecordCommand(consoleBuffer);
                 handleConsoleCommand(consoleBuffer);
 
                 consolePtr  = consoleBuffer;
@@ -553,7 +553,7 @@ static void toolsRenderCb(uint32_t winW, uint32_t winH, const emuPane_t* panes, 
     }
 }
 
-static void handleConsoleCommand(const char* command)
+void handleConsoleCommand(const char* command)
 {
     char tmpBuffer[sizeof(consoleBuffer)];
     const char* cur = command;

--- a/emulator/src/extensions/tools/ext_tools.h
+++ b/emulator/src/extensions/tools/ext_tools.h
@@ -15,6 +15,8 @@
 
 extern emuExtension_t toolsEmuExtension;
 
+void handleConsoleCommand(const char* command);
+
 bool takeScreenshot(const char* name);
 void startScreenRecording(const char* name);
 void stopScreenRecording(void);


### PR DESCRIPTION
### Description

* Adds the option to only fuzz certain buttons when fuzzing
* Adds a bunch of console commands to the emulator, mainly ones to control fuzzing
* Adds the ability to include a console command within a replay script CSV
* Documents all the existing and new console commands
* Adds a slightly more advanced help to the console
* Fixes a bug with the emulator where hiding and showing panes on the fly didn't work properly

### Test Instructions

Try some console commands, maybe try including a console command in a replay script.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
