### PR TITLE
Sundries

### DIFF
--- a/emulator/src/extensions/gamepad/ext_gamepad.c
+++ b/emulator/src/extensions/gamepad/ext_gamepad.c
@@ -153,7 +153,7 @@ bool gamepadConnect(emuJoystick_t* joystick)
     return false;
 #elif defined(EMU_LINUX)
     const char* device = "/dev/input/js0";
-    int jsFd;
+    intptr_t jsFd;
 
     jsFd = open(device, O_RDONLY | O_NONBLOCK);
     if (jsFd == -1)
@@ -201,7 +201,7 @@ void gamepadDisconnect(emuJoystick_t* joystick)
         joystick->data = NULL;
     }
 #elif defined(EMU_LINUX)
-    close((int)joystick->data);
+    close((intptr_t)joystick->data);
     joystick->data = NULL;
 #endif
 
@@ -432,7 +432,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
         struct js_event linuxEvent;
 
         errno     = 0;
-        int count = read((int)joystick->data, &linuxEvent, sizeof(struct js_event));
+        int count = read((intptr_t)joystick->data, &linuxEvent, sizeof(struct js_event));
         if (count >= (int)sizeof(struct js_event))
         {
             switch (linuxEvent.type)
@@ -480,7 +480,7 @@ bool gamepadReadEvent(emuJoystick_t* joystick, emuJoystickEvent_t* event)
                 joystick->buttonData = NULL;
             }
 
-            close((int)joystick->data);
+            close((intptr_t)joystick->data);
             joystick->data = NULL;
             return false;
         }

--- a/main/modes/games/soko/soko.c
+++ b/main/modes/games/soko/soko.c
@@ -47,6 +47,9 @@ soko_abs_t* soko = NULL;
 
 static void sokoEnterMode(void)
 {
+    // No speaker output for these puzzles! Concentrate!
+    setDacShutdown(true);
+
     soko = heap_caps_calloc(1, sizeof(soko_abs_t), MALLOC_CAP_SPIRAM);
     // Load a font
     loadFont("ibm_vga8.font", &soko->ibm, true);

--- a/main/modes/games/soko/soko.c
+++ b/main/modes/games/soko/soko.c
@@ -124,9 +124,9 @@ static void sokoEnterMode(void)
 
     // Color the menu
     led_t menuColor = {
-        .r = 0xFF,
-        .g = 0xCC,
-        .b = 0x00,
+        .r = 0xAA,
+        .g = 0x99,
+        .b = 0x99,
     };
     static const paletteColor_t shadowColors[] = {c103, c213, c224, c334, c445, c555, c445, c334, c224, c213};
     recolorMenuManiaRenderer(soko->menuManiaRenderer, //

--- a/main/modes/games/swadgeHero/mode_swadgeHero.h
+++ b/main/modes/games/swadgeHero/mode_swadgeHero.h
@@ -141,6 +141,7 @@ typedef struct
     buttonBit_t btnState;
     int32_t numFrets;
     const char* hitText;
+    paletteColor_t hitTextColor;
     const char* timingText;
     int32_t textTimerUs;
     wsg_t icons[NUM_NOTES][NUM_NOTE_FRAMES];

--- a/main/modes/games/swadgeHero/swadgeHero_game.c
+++ b/main/modes/games/swadgeHero/swadgeHero_game.c
@@ -204,9 +204,10 @@ void shLoadSong(shVars_t* sh, const shSong_t* song, shDifficulty_t difficulty)
     memset(&sh->ledHitVal, 0, sizeof(sh->ledHitVal));
 
     // Set up
-    sh->textTimerUs = 0;
-    sh->hitText     = timings[ARRAY_SIZE(timings) - 1].label;
-    sh->timingText  = hit_early;
+    sh->textTimerUs  = 0;
+    sh->hitText      = timings[ARRAY_SIZE(timings) - 1].label;
+    sh->hitTextColor = c500;
+    sh->timingText   = hit_early;
 
     // Set up icon pulse variables
     sh->iconIdx     = 0;
@@ -765,7 +766,7 @@ void shDrawGame(shVars_t* sh)
     if (sh->textTimerUs > 0)
     {
         int16_t tWidth = textWidth(&sh->ibm, sh->hitText);
-        drawText(&sh->ibm, c555, sh->hitText, (TFT_WIDTH - tWidth) / 2, 100);
+        drawText(&sh->ibm, sh->hitTextColor, sh->hitText, (TFT_WIDTH - tWidth) / 2, 100);
 
         if ((timings[0].label != sh->hitText) && (timings[ARRAY_SIZE(timings) - 1].label != sh->hitText))
         {
@@ -941,7 +942,8 @@ void shGameInput(shVars_t* sh, buttonEvt_t* evt)
                     {
                         if (usOff <= timings[tIdx].timing)
                         {
-                            sh->hitText = timings[tIdx].label;
+                            sh->hitText      = timings[tIdx].label;
+                            sh->hitTextColor = c555;
                             // Set a timer to not show the text forever
                             sh->textTimerUs = SH_TEXT_TIME;
 
@@ -1101,7 +1103,8 @@ static void shHitNote(shVars_t* sh, int32_t baseScore)
 static void shMissNote(shVars_t* sh)
 {
     // Note that it was missed
-    sh->hitText = timings[ARRAY_SIZE(timings) - 1].label;
+    sh->hitText      = timings[ARRAY_SIZE(timings) - 1].label;
+    sh->hitTextColor = c500;
     // Set a timer to not show the text forever
     sh->textTimerUs = SH_TEXT_TIME;
 

--- a/main/modes/system/intro/introMode.c
+++ b/main/modes/system/intro/introMode.c
@@ -799,7 +799,11 @@ static void introTutorialCb(tutorialState_t* state, const tutorialStep_t* prev, 
     }
 
     // TODO maybe don't hardcode this
-    if (next == (buttonsSteps + 14))
+    if (next == (buttonsSteps + 12))
+    {
+        setDacShutdown(true);
+    }
+    else if (next == (buttonsSteps + 14))
     {
         ESP_LOGI("Intro", "Oh it's the one we want: %s", next->title);
         iv->quickSettingsOpened = true;

--- a/main/modes/system/mainMenu/mainMenu.c
+++ b/main/modes/system/mainMenu/mainMenu.c
@@ -65,6 +65,7 @@ static void mainMenuExitMode(void);
 static void mainMenuMainLoop(int64_t elapsedUs);
 static void mainMenuCb(const char* label, bool selected, uint32_t settingVal);
 void addSecretsMenu(void);
+static void fanfareFinishedCb(void);
 
 //==============================================================================
 // Variables
@@ -148,6 +149,9 @@ static const char* const showSecretsMenuSettingOptions[] = {
  */
 static void mainMenuEnterMode(void)
 {
+    // Turn off DAC, for now...
+    setDacShutdown(true);
+
     // Allocate memory for the mode
     mainMenu = heap_caps_calloc(1, sizeof(mainMenu_t), MALLOC_CAP_8BIT);
 
@@ -291,7 +295,8 @@ static void mainMenuMainLoop(int64_t elapsedUs)
                 if (mainMenu->cheatCodeIdx >= ARRAY_SIZE(cheatCode))
                 {
                     mainMenu->cheatCodeIdx = 0;
-                    globalMidiPlayerPlaySong(&mainMenu->fanfare, MIDI_BGM);
+                    setDacShutdown(false);
+                    globalMidiPlayerPlaySongCb(&mainMenu->fanfare, MIDI_BGM, fanfareFinishedCb);
 #ifdef SW_VOL_CONTROL
                     mainMenu->fanfarePlaying = true;
 #endif
@@ -329,6 +334,14 @@ static void mainMenuMainLoop(int64_t elapsedUs)
     int16_t yOff         = (TFT_HEIGHT / 2) - mainMenu->font_rodin.height;
     drawTextWordWrap(&mainMenu->font_rodin, c000, warning, &xOff, &yOff, TFT_WIDTH - 12, TFT_HEIGHT);
 #endif
+}
+
+/**
+ * @brief Callback after the fanfare is done playing to disable the DAC again
+ */
+static void fanfareFinishedCb(void)
+{
+    setDacShutdown(true);
 }
 
 /**

--- a/main/modes/system/quickSettings/quickSettings.c
+++ b/main/modes/system/quickSettings/quickSettings.c
@@ -192,6 +192,9 @@ static void quickSettingsEnterMode(void)
     // Save the buzzer state and pause it
     quickSettings->buzzerState = soundSave();
 
+    // Pause the sound
+    soundPause();
+
     // Save the LED state
     getLedState(quickSettings->ledState, CONFIG_NUM_LEDS + 1);
 
@@ -288,7 +291,7 @@ static void quickSettingsExitMode(void)
 
     soundStop(true);
 
-    // Restore the buzzer state and resume it
+    // Restore the buzzer state, which may be actively playing
     soundRestore(quickSettings->buzzerState);
 
     // Restore the LED state

--- a/main/swadge2024.c
+++ b/main/swadge2024.c
@@ -498,8 +498,6 @@ void app_main(void)
             {
                 // Lower the flag
                 shouldShowQuickSettings = false;
-                // Pause the sound
-                soundPause();
 
                 // Save the current mode
                 modeBehindQuickSettings = cSwadgeMode;
@@ -515,8 +513,6 @@ void app_main(void)
                 quickSettingsMode.fnExitMode();
                 // Restore the mode
                 cSwadgeMode = modeBehindQuickSettings;
-                // Resume the sound
-                soundResume();
             }
 
             // Draw to the TFT


### PR DESCRIPTION
### Description

Fix some LED colors

Disable DAC when not in use

Fix MIDI save/restore bug

Fix warnings

### Test Instructions

* View LEDs in Hunter's Puzzle main menu, don't hear DAC whine
* Unlock secrets on main menu, hear jingle
* Complete tutorial, don't hear DAC whine
* Pause a Swadge Hero song, open and close quick settings, make sure song doesnt restart

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
