### PR TITLE
Smarter file preprocessing

### DIFF
--- a/tools/assets_preprocessor/src/bin_processor.c
+++ b/tools/assets_preprocessor/src/bin_processor.c
@@ -14,10 +14,13 @@ void process_bin(const char* infile, const char* outdir)
     strcat(outFilePath, "/");
     strcat(outFilePath, get_filename(infile));
 
-    if (doesFileExist(outFilePath))
+    if (!isSourceFileNewer(infile, outFilePath))
     {
-        // printf("Output for %s already exists\n", infile);
         return;
+    }
+    else if (doesFileExist(outFilePath))
+    {
+        printf("[assets-preprocessor] %s modified! Regenerating %s\n", infile, get_filename(outFilePath));
     }
 
     /* Read input file */

--- a/tools/assets_preprocessor/src/chart_processor.c
+++ b/tools/assets_preprocessor/src/chart_processor.c
@@ -25,10 +25,14 @@ void process_chart(const char* infile, const char* outdir)
     char* dotptr = strrchr(outFilePath, '.');
     snprintf(&dotptr[1], strlen(dotptr), "cch");
 
-    if (doesFileExist(outFilePath))
+    if (!isSourceFileNewer(infile, outFilePath))
     {
-        // printf("Output for %s already exists\n", infile);
-        // return;
+        //printf("Output for %s already exists and is up-to-date\n", infile);
+        return;
+    }
+    else if (doesFileExist(outFilePath))
+    {
+        printf("[assets-preprocessor] %s modified! Regenerating %s\n", infile, get_filename(outFilePath));
     }
 
     charSection_t section = CS_NONE;

--- a/tools/assets_preprocessor/src/fileUtils.h
+++ b/tools/assets_preprocessor/src/fileUtils.h
@@ -3,6 +3,16 @@
 
 #include <stdbool.h>
 
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) || defined(WIN32) || defined(WIN64)          \
+    || defined(_WIN32) || defined(_WIN64) || defined(__WIN32__) || defined(__CYGWIN__) || defined(__MINGW32__) \
+    || defined(__MINGW64__) || defined(__TOS_WIN__) || defined(_MSC_VER)
+    #define SAPP_WINDOWS 1
+#elif defined(__APPLE__)
+    #define SAPP_MACOS 1
+#elif defined(__linux) || defined(__linux__) || defined(linux) || defined(__LINUX__)
+    #define SAPP_LINUX 1
+#endif
+
 #define HI_WORD(x) ((x >> 16) & 0xFFFF)
 #define LO_WORD(x) ((x) & 0xFFFF)
 #define HI_BYTE(x) ((x >> 8) & 0xFF)
@@ -11,5 +21,6 @@
 long getFileSize(const char* fname);
 bool doesFileExist(const char* fname);
 const char* get_filename(const char* filename);
+bool isSourceFileNewer(const char* sourceFile, const char* destFile);
 
 #endif

--- a/tools/assets_preprocessor/src/fileUtils.h
+++ b/tools/assets_preprocessor/src/fileUtils.h
@@ -3,16 +3,6 @@
 
 #include <stdbool.h>
 
-#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) || defined(WIN32) || defined(WIN64)          \
-    || defined(_WIN32) || defined(_WIN64) || defined(__WIN32__) || defined(__CYGWIN__) || defined(__MINGW32__) \
-    || defined(__MINGW64__) || defined(__TOS_WIN__) || defined(_MSC_VER)
-    #define SAPP_WINDOWS 1
-#elif defined(__APPLE__)
-    #define SAPP_MACOS 1
-#elif defined(__linux) || defined(__linux__) || defined(linux) || defined(__LINUX__)
-    #define SAPP_LINUX 1
-#endif
-
 #define HI_WORD(x) ((x >> 16) & 0xFFFF)
 #define LO_WORD(x) ((x) & 0xFFFF)
 #define HI_BYTE(x) ((x >> 8) & 0xFF)

--- a/tools/assets_preprocessor/src/font_processor.c
+++ b/tools/assets_preprocessor/src/font_processor.c
@@ -79,9 +79,6 @@ void appendCharToFile(FILE* fp, unsigned char* data, int w, int h, int charStart
  */
 void process_font(const char* infile, const char* outdir)
 {
-    /* Load the font PNG */
-    int w, h, n;
-    unsigned char* data = stbi_load(infile, &w, &h, &n, 4);
 
     /* Open up the output file */
     char outFilePath[128] = {0};
@@ -90,6 +87,20 @@ void process_font(const char* infile, const char* outdir)
     strcat(outFilePath, get_filename(infile));
     /* Clip off the ".png", leaving ".font" */
     *(strrchr(outFilePath, '.')) = 0;
+
+    if (!isSourceFileNewer(infile, outFilePath))
+    {
+        return;
+    }
+    else if (doesFileExist(outFilePath))
+    {
+        printf("[assets-preprocessor] %s modified! Regenerating %s\n", infile, get_filename(outFilePath));
+    }
+
+    /* Load the font PNG */
+    int w, h, n;
+    unsigned char* data = stbi_load(infile, &w, &h, &n, 4);
+
     FILE* fp                     = fopen(outFilePath, "wb+");
 
     int charsWritten = 0;

--- a/tools/assets_preprocessor/src/image_processor.c
+++ b/tools/assets_preprocessor/src/image_processor.c
@@ -136,10 +136,13 @@ void process_image(const char* infile, const char* outdir)
     char* dotptr = strrchr(outFilePath, '.');
     snprintf(&dotptr[1], strlen(dotptr), "wsg");
 
-    if (doesFileExist(outFilePath))
+    if (!isSourceFileNewer(infile, outFilePath))
     {
-        // printf("Output for %s already exists\n", infile);
         return;
+    }
+    else if (doesFileExist(outFilePath))
+    {
+        printf("[assets-preprocessor] %s modified! Regenerating %s\n", infile, get_filename(outFilePath));
     }
 
     /* Load the source PNG */

--- a/tools/assets_preprocessor/src/json_processor.c
+++ b/tools/assets_preprocessor/src/json_processor.c
@@ -25,11 +25,14 @@ void process_json(const char* infile, const char* outdir)
     snprintf(&dotptr[1], strlen(dotptr), "hjs");
 #endif
 
-    // if(doesFileExist(outFilePath))
-    // {
-    //     printf("Output for %s already exists\n", infile);
-    //     return;
-    // }
+    if (!isSourceFileNewer(infile, outFilePath))
+    {
+        return;
+    }
+    else if (doesFileExist(outFilePath))
+    {
+        printf("[assets-preprocessor] %s modified! Regenerating %s\n", infile, get_filename(outFilePath));
+    }
 
     /* Read input file */
     FILE* fp = fopen(infile, "rb");

--- a/tools/assets_preprocessor/src/raw_processor.c
+++ b/tools/assets_preprocessor/src/raw_processor.c
@@ -20,10 +20,13 @@ void process_raw(const char* inFile, const char* outDir, const char* outExt)
     char* dotPtr = strrchr(outFilePath, '.');
     strncpy(&dotPtr[1], outExt, sizeof(outFilePath) - (dotPtr - outFilePath) - 1);
 
-    if (doesFileExist(outFilePath))
+    if (!isSourceFileNewer(inFile, outFilePath))
     {
-        // printf("Output for %s already exists\n", inFile);
         return;
+    }
+    else if (doesFileExist(outFilePath))
+    {
+        printf("[assets-preprocessor] %s modified! Regenerating %s\n", inFile, get_filename(outFilePath));
     }
 
     // Read input file

--- a/tools/assets_preprocessor/src/rmd_processor.c
+++ b/tools/assets_preprocessor/src/rmd_processor.c
@@ -20,11 +20,14 @@ void process_rmd(const char* infile, const char* outdir)
     char* dotptr = strrchr(outFilePath, '.');
     snprintf(&dotptr[1], strlen(dotptr), "rmh");
 
-    // if(doesFileExist(outFilePath))
-    // {
-    //     printf("Output for %s already exists\n", infile);
-    //     return;
-    // }
+    if(!isSourceFileNewer(infile, outFilePath))
+    {
+        return;
+    }
+    else if (doesFileExist(outFilePath))
+    {
+        printf("[assets-preprocessor] %s modified! Regenerating %s\n", infile, get_filename(outFilePath));
+    }
 
     /* Read input file */
     FILE* fp = fopen(infile, "rb");

--- a/tools/assets_preprocessor/src/txt_processor.c
+++ b/tools/assets_preprocessor/src/txt_processor.c
@@ -41,10 +41,13 @@ void process_txt(const char* infile, const char* outdir)
     strcat(outFilePath, "/");
     strcat(outFilePath, get_filename(infile));
 
-    if (doesFileExist(outFilePath))
+    if (!isSourceFileNewer(infile, outFilePath))
     {
-        // printf("Output for %s already exists\n", infile);
         return;
+    }
+    else if (doesFileExist(outFilePath))
+    {
+        printf("[assets-preprocessor] %s modified! Regenerating %s\n", infile, get_filename(outFilePath));
     }
 
     /* Read input file */


### PR DESCRIPTION
### Description
Basically, this fixes having to ever run `make fullclean`, because I constantly forget and waste too much time trying to fix imaginary problems. It also fixes the inconsistency of some assets always being recreated and some never being recreated. This does change the `doesFileExist()` implementation to one that doesn't create the file if it doesn't exist, because I wanted to check in multiple places. Eventually I want to refactor the asset preprocessor a bit to unify all the boilerplate so that can go back but that's a later thing.

Adds a utility function to the assets preprocessor for checking whether one file is newer than another. All asset processors now only process an asset if either the destination does not exist, or if the source file is newer than the destination file. Basically what Make does. Also adds a log message for when a file is being reprocessed, but not when it's being created the first time.

### Test Instructions

Tested on Linux & Windows (non-WSL).

1. Do a `make fullclean`
2. `make` - there shouldn't be any new log messages when creating assets for the first time
3. Update one of the files in `assets/` by either using `touch <file>` or by actually modifying it.
4. Run `make` again; there should be a log message about the asset being regenerated and nothing else.
5. Delete a file in `assets_image`
6. Run `make` again; the file in `assets_image` should be recreated, and without a log message being printed for it


### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
