### PR TITLE
Fix TTT CPU Difficulty Selector

### DIFF
--- a/main/modes/games/ultimateTTT/ultimateTTTgame.c
+++ b/main/modes/games/ultimateTTT/ultimateTTTgame.c
@@ -100,8 +100,10 @@ void tttBeginGame(ultimateTTT_t* ttt)
     memset(ttt->game.cellTimers, 0, sizeof(ttt->game.cellTimers));
     memset(ttt->game.gameTimers, 0, sizeof(ttt->game.gameTimers));
 
-    /// Clear any CPU data
+    /// Clear any CPU data, preserving difficulty
+    tttCpuDifficulty_t origDiff = ttt->game.cpu.difficulty;
     memset(&ttt->game.cpu, 0, sizeof(ttt->game.cpu));
+    ttt->game.cpu.difficulty = origDiff;
 
     // Show the game UI
     tttShowUi(TUI_GAME);


### PR DESCRIPTION
### Description

Fixes the difficulty being lost when the CPU player data is reset.

### Test Instructions

Try hard mode and see if it's actually hard.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
