### PR TITLE
Fix TTT Hard AI Subgame Selection

### DIFF
--- a/main/modes/games/pango/paSoundManager.c
+++ b/main/modes/games/pango/paSoundManager.c
@@ -60,7 +60,7 @@ bool pa_setBgm(paSoundManager_t* self, uint16_t newBgmIndex)
     // All BGM's are intended to loop!
     midiPlayer_t* player = globalMidiPlayerGet(MIDI_BGM);
     player->loop         = true;
-    
+
     if (self->currentBgmIndex == newBgmIndex)
     {
         return false;

--- a/main/modes/games/ultimateTTT/ultimateTTTcpuPlayer.c
+++ b/main/modes/games/ultimateTTT/ultimateTTTcpuPlayer.c
@@ -1201,53 +1201,49 @@ static bool analyzeMove(const tttSubgame_t subgames[3][3], const move_t* move, t
     memcpy(&lastMove, move, sizeof(move_t));
     int moveNum = 0;
 
+    
+    board[lastMove.subX][lastMove.subY].game[lastMove.cellX][lastMove.cellY] = player;
+
+    // Check if that wins the cell and update it accordingly
+    tttPlayer_t subgameWinner = tttCheckWinner(board[lastMove.subX][lastMove.subY].game);
+    if (subgameWinner != TTT_NONE)
     {
-        board[lastMove.subX][lastMove.subY].game[lastMove.cellX][lastMove.cellY] = player;
+        board[lastMove.subX][lastMove.subY].winner = subgameWinner;
+    }
 
-        // Check if that wins the cell and update it accordingly
-        tttPlayer_t subgameWinner = tttCheckWinner(board[lastMove.subX][lastMove.subY].game);
-        if (subgameWinner != TTT_NONE)
+    // Get the overall board to check the game's status
+    tttPlayer_t bigBoard[3][3];
+    for (int gx = 0; gx < 3; gx++)
+    {
+        for (int gy = 0; gy < 3; gy++)
         {
-            board[lastMove.subX][lastMove.subY].winner = subgameWinner;
+            bigBoard[gx][gy] = board[gx][gy].winner;
         }
+    }
 
-        // Get the overall board to check the game's status
-        tttPlayer_t bigBoard[3][3];
-        for (int gx = 0; gx < 3; gx++)
-        {
-            for (int gy = 0; gy < 3; gy++)
-            {
-                bigBoard[gx][gy] = board[gx][gy].winner;
-            }
-        }
-
-        tttPlayer_t winner = tttCheckWinner(bigBoard);
-        if (winner == player)
-        {
-            result->winsGame   = true;
-            result->losesGame  = false;
-            result->movesToEnd = moveNum;
-            memset(&result->bestOpponentMove, 0, sizeof(move_t));
-            return true;
-        }
-        else if (winner == opponent)
-        {
-            result->winsGame   = false;
-            result->losesGame  = true;
-            result->movesToEnd = moveNum;
-            memcpy(&result->bestOpponentMove, &lastMove, sizeof(move_t));
-            return true;
-        }
-        else
-        {
-            // TTT_NONE
-            result->winsGame  = false;
-            result->losesGame = false;
-            return true;
-        }
-
-        turn = (turn == TTT_P1) ? TTT_P2 : TTT_P1;
-        moveNum++;
+    tttPlayer_t winner = tttCheckWinner(bigBoard);
+    if (winner == player)
+    {
+        result->winsGame   = true;
+        result->losesGame  = false;
+        result->movesToEnd = moveNum;
+        memset(&result->bestOpponentMove, 0, sizeof(move_t));
+        return true;
+    }
+    else if (winner == opponent)
+    {
+        result->winsGame   = false;
+        result->losesGame  = true;
+        result->movesToEnd = moveNum;
+        memcpy(&result->bestOpponentMove, &lastMove, sizeof(move_t));
+        return true;
+    }
+    else
+    {
+        // TTT_NONE
+        result->winsGame  = false;
+        result->losesGame = false;
+        return true;
     }
 
     return false;

--- a/main/modes/games/ultimateTTT/ultimateTTTcpuPlayer.c
+++ b/main/modes/games/ultimateTTT/ultimateTTTcpuPlayer.c
@@ -324,15 +324,13 @@ static bool selectSubgame_medium(ultimateTTT_t* ttt, int* x, int* y)
 
 static bool selectSubgame_hard(ultimateTTT_t* ttt, int* x, int* y)
 {
-    // Eventually this will become the medium difficulty once I get the actual difficult AI working
-    // Here's what to do:
     // - Construct a 'subgame' to match the main board (which we can modify if needed to simulate stuff) and also to
     // avoid rewriting the algorithm
     // - Its board will have all the completed subgames marked with the winner, and the rest as NONE (TODO: how to
     // handle a tie??? Just use the TIE player? Yeah probably)
     // - We calculate the next possible move on that board, and then take a look at the board we'd need to win to get
     // our marker there
-    // - So... I guess we should take all the possiblebest overal moves in that board, and then what...
+    // But also check every valid move for a game-winning move, and try that first
 
     // Who are we?
     tttPlayer_t cpuPlayer = (ttt->game.singlePlayerPlayOrder == GOING_FIRST) ? TTT_P2 : TTT_P1;

--- a/main/modes/games/ultimateTTT/ultimateTTTcpuPlayer.c
+++ b/main/modes/games/ultimateTTT/ultimateTTTcpuPlayer.c
@@ -1199,7 +1199,6 @@ static bool analyzeMove(const tttSubgame_t subgames[3][3], const move_t* move, t
     memcpy(&lastMove, move, sizeof(move_t));
     int moveNum = 0;
 
-    
     board[lastMove.subX][lastMove.subY].game[lastMove.cellX][lastMove.cellY] = player;
 
     // Check if that wins the cell and update it accordingly

--- a/main/modes/games/ultimateTTT/ultimateTTTcpuPlayer.c
+++ b/main/modes/games/ultimateTTT/ultimateTTTcpuPlayer.c
@@ -98,7 +98,8 @@ static rowCount_t checkDiag(const tttPlayer_t game[3][3], int n, tttPlayer_t pla
 
 static uint16_t movesToWin(const tttPlayer_t subgame[3][3], tttPlayer_t player);
 static uint16_t analyzeSubgame(const tttPlayer_t subgame[3][3], tttPlayer_t player, uint16_t filter);
-static bool analyzeMove(const tttSubgame_t subgames[3][3], const move_t* move, tttPlayer_t player, moveAnalysis_t* result);
+static bool analyzeMove(const tttSubgame_t subgames[3][3], const move_t* move, tttPlayer_t player,
+                        moveAnalysis_t* result);
 
 const char* getMoveName(uint16_t move);
 void printGame(const tttPlayer_t subgame[3][3]);
@@ -338,7 +339,7 @@ static bool selectSubgame_hard(ultimateTTT_t* ttt, int* x, int* y)
 
     // To avoid a second pass
     int32_t maxScore = INT32_MIN;
-    move_t maxMove = {0};
+    move_t maxMove   = {0};
 
     // The whole game turned into a subgame
     tttPlayer_t subgame[3][3];
@@ -357,8 +358,8 @@ static bool selectSubgame_hard(ultimateTTT_t* ttt, int* x, int* y)
                         int score = INT32_MIN;
 
                         move_t move = {
-                            .subX = gx,
-                            .subY = gy,
+                            .subX  = gx,
+                            .subY  = gy,
                             .cellX = cx,
                             .cellY = cy,
                         };
@@ -387,9 +388,9 @@ static bool selectSubgame_hard(ultimateTTT_t* ttt, int* x, int* y)
 
                         if (score > maxScore)
                         {
-                            maxScore = score;
-                            maxMove.subX = gx;
-                            maxMove.subY = gy;
+                            maxScore      = score;
+                            maxMove.subX  = gx;
+                            maxMove.subY  = gy;
                             maxMove.cellX = cx;
                             maxMove.cellY = cy;
                         }
@@ -399,10 +400,10 @@ static bool selectSubgame_hard(ultimateTTT_t* ttt, int* x, int* y)
         }
     }
 
-    uint16_t mainResult   = analyzeSubgame(subgame, cpuPlayer, 0);
-    uint16_t mainMove     = DECODE_MOVE(mainResult);
-    int mainX             = DECODE_LOC_X(mainResult);
-    int mainY             = DECODE_LOC_Y(mainResult);
+    uint16_t mainResult = analyzeSubgame(subgame, cpuPlayer, 0);
+    uint16_t mainMove   = DECODE_MOVE(mainResult);
+    int mainX           = DECODE_LOC_X(mainResult);
+    int mainY           = DECODE_LOC_Y(mainResult);
 
     // Override the best subgame if there's a winning move
     if (maxScore == INT32_MAX)
@@ -1181,10 +1182,12 @@ static uint16_t analyzeSubgame(const tttPlayer_t subgame[3][3], tttPlayer_t play
     return 0;
 }
 
-static bool analyzeMove(const tttSubgame_t subgames[3][3], const move_t* move, tttPlayer_t player, moveAnalysis_t* result)
+static bool analyzeMove(const tttSubgame_t subgames[3][3], const move_t* move, tttPlayer_t player,
+                        moveAnalysis_t* result)
 {
     tttSubgame_t board[3][3];
-    if (subgames[move->subX][move->subY].winner != TTT_NONE || subgames[move->subX][move->subY].game[move->cellX][move->cellY] != TTT_NONE)
+    if (subgames[move->subX][move->subY].winner != TTT_NONE
+        || subgames[move->subX][move->subY].game[move->cellX][move->cellY] != TTT_NONE)
     {
         // Impossible move!
         return false;
@@ -1193,8 +1196,8 @@ static bool analyzeMove(const tttSubgame_t subgames[3][3], const move_t* move, t
     memcpy(board, subgames, sizeof(board));
 
     const tttPlayer_t opponent = (player == TTT_P1) ? TTT_P2 : TTT_P1;
-    tttPlayer_t turn = player;
-    move_t lastMove = {0};
+    tttPlayer_t turn           = player;
+    move_t lastMove            = {0};
     memcpy(&lastMove, move, sizeof(move_t));
     int moveNum = 0;
 
@@ -1221,16 +1224,16 @@ static bool analyzeMove(const tttSubgame_t subgames[3][3], const move_t* move, t
         tttPlayer_t winner = tttCheckWinner(bigBoard);
         if (winner == player)
         {
-            result->winsGame = true;
-            result->losesGame = false;
+            result->winsGame   = true;
+            result->losesGame  = false;
             result->movesToEnd = moveNum;
             memset(&result->bestOpponentMove, 0, sizeof(move_t));
             return true;
         }
         else if (winner == opponent)
         {
-            result->winsGame = false;
-            result->losesGame = true;
+            result->winsGame   = false;
+            result->losesGame  = true;
             result->movesToEnd = moveNum;
             memcpy(&result->bestOpponentMove, &lastMove, sizeof(move_t));
             return true;
@@ -1238,7 +1241,7 @@ static bool analyzeMove(const tttSubgame_t subgames[3][3], const move_t* move, t
         else
         {
             // TTT_NONE
-            result->winsGame = false;
+            result->winsGame  = false;
             result->losesGame = false;
             return true;
         }

--- a/main/modes/games/ultimateTTT/ultimateTTTgame.c
+++ b/main/modes/games/ultimateTTT/ultimateTTTgame.c
@@ -99,6 +99,8 @@ void tttBeginGame(ultimateTTT_t* ttt)
     ttt->game.moveAnimTimer = MOVE_ANIM_TIME;
     memset(ttt->game.cellTimers, 0, sizeof(ttt->game.cellTimers));
     memset(ttt->game.gameTimers, 0, sizeof(ttt->game.gameTimers));
+    memset(ttt->game.priorCellAnim, 0, sizeof(ttt->game.priorCellAnim));
+    memset(ttt->game.nextSubgameAnim, 0, sizeof(ttt->game.nextSubgameAnim));
 
     /// Clear any CPU data, preserving difficulty
     tttCpuDifficulty_t origDiff = ttt->game.cpu.difficulty;

--- a/main/modes/games/ultimateTTT/ultimateTTTgame.c
+++ b/main/modes/games/ultimateTTT/ultimateTTTgame.c
@@ -100,8 +100,10 @@ void tttBeginGame(ultimateTTT_t* ttt)
     memset(ttt->game.cellTimers, 0, sizeof(ttt->game.cellTimers));
     memset(ttt->game.gameTimers, 0, sizeof(ttt->game.gameTimers));
 
-    /// Clear any CPU data
+    /// Clear any CPU data, preserving difficulty
+    tttCpuDifficulty_t origDiff = ttt->game.cpu.difficulty;
     memset(&ttt->game.cpu, 0, sizeof(ttt->game.cpu));
+    ttt->game.cpu.difficulty = origDiff;
 
     // Show the game UI
     tttShowUi(TUI_GAME);

--- a/main/modes/utilities/gamepad/gamepad.c
+++ b/main/modes/utilities/gamepad/gamepad.c
@@ -294,7 +294,7 @@ void gamepadEnterMode(void)
     addSingleItemToMenu(gamepad->menu, str_exit);
 
     // Initialize menu renderer
-    gamepad->renderer = initMenuManiaRenderer(NULL, NULL, NULL);
+    gamepad->renderer         = initMenuManiaRenderer(NULL, NULL, NULL);
     gamepad->renderer->ledsOn = false;
 
     // Set up the IMU


### PR DESCRIPTION
### Description

Fixes the subgame selection algorithm of the hard TTT AI to prioritize winning the game over winning a subgame when the game can be won multiple ways.

Adds a function that just does a `checkWin()` against a copy of the game board with a hypothetical move, and uses that to check every possible move in the select subgame algorithm for hard mode. This seems fast enough, I haven't noticed any issues with it on hardware.

Also fixes the yellow 'next subgame' animation square remaining visible at its last location when a new game is started. In order for it to show up, you have to finish a game then start another, and it would be there.

### Test Instructions

Tested by playing some hard games. In particular it had trouble with the situation where these subgames are already won, with the bottom-right subgame being one move away from winning (and the center-left subgame not):
```
 X |   |   
   | X | X
   |    | 
```
Previously the AI would pick the center-left subgame, even if it had no other markers in that subgame, and ignore the bottom-right subgame, which could immediately be won.

### Ticket Links
Fixes #399 

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
