### PR TITLE
Minor makefile fixes

### DIFF
--- a/makefile
+++ b/makefile
@@ -397,8 +397,10 @@ fullclean: clean
 # Utility targets
 ################################################################################
 
-docs:
+plantuml.jar:
 	-wget -nc -O plantuml.jar https://github.com/plantuml/plantuml/releases/download/v1.2023.4/plantuml-1.2023.4.jar
+
+docs: plantuml.jar
 	doxygen ./Doxyfile
 
 format:

--- a/makefile
+++ b/makefile
@@ -36,9 +36,9 @@ ifeq ($(HOST_OS),Windows)
 endif
 
 # clang-format may actually be clang-format-17
-CLANG_FORMAT:=clang-format
+CLANG_FORMAT:=clang-format-17
 ifeq (, $(shell which $(CLANG_FORMAT)))
-	CLANG_FORMAT:=clang-format-17
+	CLANG_FORMAT:=clang-format
 endif
 
 ifeq ($(HOST_OS),Linux)


### PR DESCRIPTION
### Description

Fixes a couple things that bothered me just now.

1. Prioritize `clang-format-17` over the default one, because my new laptop is on a new fedora which comes with `clang-format` 19, which of course disagrees with 17 so I have to keep changing the makefile.
2. Add a separate makefile target for `wget plantuml.jar` instead of running it in `make docs`. Not sure why, but every time I ran `make docs` it would print a message saying plantuml.jar was already present and won't be downloaded, but then it downloaded it anyway.

### Test Instructions

Tested by running `make format` and `make docs` on several different machines with different versions of stuff. Seemed to work fine to me!

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
