### PR TITLE
Fix warnings and the replay extension

### DIFF
--- a/emulator/src/extensions/replay/ext_replay.c
+++ b/emulator/src/extensions/replay/ext_replay.c
@@ -584,6 +584,7 @@ static bool readEntry(replayEntry_t* entry)
                 printf("ERR: Can't find button matching '%s'\n", buffer);
                 return false;
             }
+            entry->buttonVal = button;
 
             break;
         }

--- a/emulator/src/extensions/tools/emu_console_cmds.c
+++ b/emulator/src/extensions/tools/emu_console_cmds.c
@@ -657,15 +657,12 @@ static int joystickCommandCb(const char** args, int argCount, char* out)
             // Enable and connect to named device
             disableExtension("gamepad");
 
-            if (deviceName == NULL)
+            if (deviceName != NULL)
             {
                 strncpy(joyDevName, deviceName, sizeof(joyDevName));
-                emulatorArgs.joystick = joyDevName;
             }
-            else
-            {
-                emulatorArgs.joystick = joyDevName;
-            }
+
+            emulatorArgs.joystick = joyDevName;
 
             enableExtension("gamepad");
 

--- a/main/modes/games/ultimateTTT/ultimateTTTcpuPlayer.c
+++ b/main/modes/games/ultimateTTT/ultimateTTTcpuPlayer.c
@@ -1194,7 +1194,6 @@ static bool analyzeMove(const tttSubgame_t subgames[3][3], const move_t* move, t
     memcpy(board, subgames, sizeof(board));
 
     const tttPlayer_t opponent = (player == TTT_P1) ? TTT_P2 : TTT_P1;
-    tttPlayer_t turn           = player;
     move_t lastMove            = {0};
     memcpy(&lastMove, move, sizeof(move_t));
     int moveNum = 0;

--- a/main/modes/system/intro/introMode.c
+++ b/main/modes/system/intro/introMode.c
@@ -528,7 +528,6 @@ static void introMainLoop(int64_t elapsedUs)
         const paletteColor_t outlineCol     = c025;
         const paletteColor_t textCol        = c025;
 
-        paletteColor_t* screen = getPxTftFramebuffer();
         for (int i = 0; i < TFT_WIDTH; i++)
         {
             drawLineFast(i, 0, i, TFT_HEIGHT, bgLineColors[i % 2]);
@@ -554,7 +553,6 @@ static void introMainLoop(int64_t elapsedUs)
         int16_t festX = magX + magW + 1 + kernAG;
 
         int16_t subOneWidth = textWidth(&iv->logoFont, sub);
-        int16_t subTwoWidth = textWidth(&iv->logoFont, sub2);
         int16_t kernWA      = -8;
         int16_t subWidth    = textWidth(&iv->logoFont, sub) + textWidth(&iv->logoFont, sub2) + kernWA + 1;
         int16_t subX        = (TFT_WIDTH - subWidth) / 2;


### PR DESCRIPTION
### Description

Fix a couple warnings plus a logic error, and a line I deleted and accidentally broke the replay extension with.

### Test Instructions

<!--- How was this tested? -->

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
