### PR TITLE
Fix gamepad not exiting if Menu/Pause are pressed at the exact same time

### DIFF
--- a/main/modes/utilities/gamepad/gamepad.c
+++ b/main/modes/utilities/gamepad/gamepad.c
@@ -697,7 +697,7 @@ void gamepadMainLoop(int64_t elapsedUs __attribute__((unused)))
  */
 void gamepadButtonCb(buttonEvt_t* evt)
 {
-    if (evt->button == PB_START || evt->button == PB_SELECT)
+    if (evt->button == PB_START || evt->button == PB_SELECT || evt->button == (PB_START | PB_SELECT))
     {
         if ((evt->state & PB_START) && (evt->state & PB_SELECT))
         {


### PR DESCRIPTION
### Description

If you exit gamepad by hitting Start & Select at the _exact same time_, you'll get an event with `(PB_START | PB_SELECT)` as the value, and it doesn't trigger the condition at all.

### Test Instructions

Tested with a swadge in gamepad mode.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
