### PR TITLE
Fix infinite loop when exiting BigBug

### DIFF
--- a/main/modes/games/bigbug/gameData_bigbug.c
+++ b/main/modes/games/bigbug/gameData_bigbug.c
@@ -206,7 +206,7 @@ void bb_freeGameData(bb_gameData_t* gameData)
     }
     while (gameData->pleaseCheck.first)
     {
-        heap_caps_free(shift(&gameData->unsupported));
+        heap_caps_free(shift(&gameData->pleaseCheck));
     }
     if (gameData->loadoutScreenData != NULL)
     {


### PR DESCRIPTION
### Description

<!--- What was added and/or fixed in this pull request? -->

### Test Instructions

Be in the middle of a level in big bug and try to exit. Sometimes it hangs forever

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [ ] I have run `make format` to format the changes
- [ ] I have compiled the firmware and the changes have no warnings
- [ ] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
