### PR TITLE
Docs - typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This project uses Github Actions to automatically build the firmware, emulator, 
 - [`.github`](./.github): Issue templates and CI workflows for GitHub
 - [`.vscode`](./.vscode): Configurations for [Visual Studio Code](https://code.visualstudio.com/)
 - [`docs`](./docs): Documentation 
-- [`attic`](./attic): Where old Swdage modes go when they're not being compiled into firmware
+- [`attic`](./attic): Where old Swadge modes go when they're not being compiled into firmware
 
 ## Troubleshooting
 

--- a/docs/DESIGN_PRINCIPLES.md
+++ b/docs/DESIGN_PRINCIPLES.md
@@ -1,0 +1,77 @@
+# Swadge Global Design Document
+
+The principles here should guide the development of a Swadge’s hardware and firmware. Most of the principles here are guidelines, not hard requirements. When in doubt, talk out ideas in our Slack channel, #super-circuitboards.
+
+## General Design Principles
+- Swadges should not largely rely on at-event infrastructure and should be fully usable after Magfest.
+  - This principle may be broken if the feature that requires infrastructure is really cool. Talk it out in the Slack channel first before requiring infrastructure.
+- At least one Swadge mode should have wireless connectivity features, like a PvP game
+  - Wireless connectivity between Swadges may be less useful after Magfest.
+- If a Swadge is turned on and left idle, it should display cool flashing LEDS.
+  - This idle mode should be as power-efficient as possible
+- Swadges should have at least one secret or easter egg
+
+## Swadge Mode Design Principles
+- Modes should try to fit the current theme of the event by:
+  - Using themed sprites
+  - Using a themed font
+  - Using the theme’s colors
+- Modes should use as much available hardware as possible, including, but not limited to:
+  - LED effects
+  - Sound effects
+  - Accelerometer input
+  - Touchpad input
+- Modes should be polished, which means:
+  - No bugs
+  - Looks pretty
+  - Has intuitive UI
+- Modes should be simple. Overly complex modes are hard to explain and understand, and users will engage with them less.
+  - Guided tutorials are good. If there is one, force users to do it once. Tutorials should also be easily accessible to do again.
+  - Learning through gameplay by gradually introducing mechanics is great. This is how Nintendo gamifies learning.
+- Modes should be designed with a playtime of 1-5 minutes per session.
+  - Larger games should have a way to save progress at this interval.
+  - Modes should save options between sessions.
+- Modes should have an incentive to play and should celebrate🎉 when progress is made. Incentives can be:
+  - Unlockable assets (pictures, songs)
+  - Unlockable gameplay (new characters, new levels)
+  - A story that progresses
+  - Getting a high score (this is kind of boring alone, make sure there’s flair🎊)
+
+## Hardware Design Principles
+- The Swadge shape must be designed to the fit the theme of the event
+  - A distinctive theme-specific silhouette is preferable
+  - The shape should consider ergonomics
+- The Swadge must be designed to be worn on a lanyard.
+- There must be two Swadge variants, one for pre-order and one for purchase at Magfest
+  - The two Swadge variants should have a sufficiently distinct color scheme.
+  - Think of the pre-order Swadge like a Shiny Pokemon
+- The Swadge should be physically durable. Use cases include:
+  - Dangling on a lanyard when dancing at a concert
+  - Being shoved in a tight bag during transit
+- If the Swadge uses new or delicate parts, destructively test them until we’re confident the failure rate is near zero.
+- The Swadge should only include hardware if it is used by modes.
+  - For example, do not include an accelerometer if it is used by very few modes.
+- If applicable, have a way to calibrate analog inputs.
+- Battery life should last the duration of the event with standard use.
+- Physical user interface should be intuitive.
+  - D-Pad input is common and well understood.
+  - A dedicated mode select button is better than a button combo or menu option.
+  - Buttons should have silkscreen labels.
+- The Swadge may have 3D printable accessories
+  - If we sell accessories, they must be budgeted ahead of time and ordered at the same time as the Swadges themselves.
+  - If being sold, print files for accessories should be made publicly available two weeks before Magfest.
+  - If not being sold, print files can be made available as early as desired.
+
+## Manual Design Principles
+- The manual should fit on an 8.5x11” sheet of paper, double sided
+  - The sheet of paper may be folded
+  - A high-polish manual is hard to make and even harder to sell
+- The manual should be posted to https://swadge.com/ in HTML form
+  - Posting a PDF of the manual is fine, but making a web friendly version is better
+- The manual may be included in the Swadge itself if practical
+
+## Firmware Development Principles
+- Before development begins, an outline and feature milestones of the mode should be written down and shared with the team.
+- Some milestones should be designated as the ‘finished mode.’ It’s OK to have milestones after this point, like stretch goals.
+- At each milestone, the mode should be shown off to the team, to receive feedback and guide development
+- Work on optional milestones only after essential milestones are completed

--- a/docs/EMULATOR.md
+++ b/docs/EMULATOR.md
@@ -24,7 +24,7 @@ The Linux version of the emulator does not require any other software to operate
 `.zip` file anywhere you like and run the `swadge_emulator` program, either by opening it from your
 file browser or by running `./swadge_emulator` from the command-line. The Linux emulator includes a
 script, `install.sh`, which can be run to install the Swadge Emulator as a desktop application, which
-will allow you to open the emulator directly from many desktop environments, and to asssociate the
+will allow you to open the emulator directly from many desktop environments, and to associate the
 emulator with MIDI files using the "Open with..." option in your file browser. If you do not want these
 features, there is no need to run the script. You will need to run this script again if you download a
 new version of the emulator. By default, the installation script will install to `~/.local`, but you
@@ -158,8 +158,8 @@ the Escape key can be used to exit the emulator.
 
 `--show-fps`: Displays an FPS counter below the emulator screen.
 
-`--touch`: Displays a simulated tocuhpad below the emulator screen. Clicking on this touchpad will generate
-touch events that will be read by any swadge mode that uses the touchpad.
+`--touch`: Displays a simulated touchpad below the emulator screen. Clicking on this touchpad will generate
+touch events that will be read by any Swadge mode that uses the touchpad.
 
 `--vsync`: Controls whether VSync is enabled. When VSync is enabled (the default behavior), the Swadge
 Emulator's frame rate will be capped at the monitor's refresh rate. If disabled with `--vsync no`, the
@@ -170,7 +170,7 @@ emulator will run as fast as possible. Note that this may not be supported by al
 These options allow inputs to the emulator to be recorded and played back later. This can be useful when
 repeatedly performing the same actions during debugging, for sharing with others, or just for convenience.
 
-`--record`: Record the inputs to the swadge emulator in a recording file. If no name is given, a default
+`--record`: Record the inputs to the Swadge emulator in a recording file. If no name is given, a default
 recording filename will be generated in the form `rec-<timestamp>.csv`. While recording, all button presses
 and touchpad inputs will be written to the recording file, in addition to:
 
@@ -201,7 +201,7 @@ A recording file is a CSV (comma-separated value) file with three columns: Time,
 | Fuzz           | -                     | Start fuzzing the emulator                                   |
 | Quit           | -                     | Exit the emulator immediately                                |
 | Screenshot     | Screenshot filename   | Take a screenshot, using a default filename if none is given |
-| SetMode        | Mode name             | Switch swadge modes to the named mode                        |
+| SetMode        | Mode name             | Switch Swadge modes to the named mode                        |
 | Seed           | Seed value            | Set the PRNG seed. This should be the first entry in a file  |
 | Command        | Console command       | Execute an arbitrary console command                         |
 
@@ -241,7 +241,7 @@ every frame.
 
 `--fuzz-motion`: Enable or disable fuzzing of accelometer motion only.
 
-`--mode-switch`: Automatically switch to a random swadge mode after the specified number of seconds has
+`--mode-switch`: Automatically switch to a random Swadge mode after the specified number of seconds has
 passed, repeatedly. For example, `swadge_emulator --mode-switch 5` would switch to a random mode every
 5 seconds. If no value is given, modes will be switched every 10 seconds.
 
@@ -256,21 +256,21 @@ mode's name, that mode will be used. For example, `swadge_emulator --mode Co` wi
 `swadge_emulator --mode Cr` will open `Credits`. If the name is ambiguous, the first matching mode in the
 list will be used; use `--modes` for the list and its order.
 
-`--modes`: Lists all known swadge modes that can be started using the `--mode` argument.
+`--modes`: Lists all known Swadge modes that can be started using the `--mode` argument.
 
 `--headless`: Starts this emulator without a visible window. The emulator will still run and render
 its graphics to an internal display, but there will be no way to directly interact with the emulator.
 
 `--fake-fps`: Simulate a lower framerate without actually changing the speed at which the emulator runs.
-For example, passing `--fake-fps 1` will cause each frame to have a duration of  second from the perspective
-of a swadge mode. Because the number of actual frames per second doesn't change, this means that 60 seconds
+For example, passing `--fake-fps 1` will cause each frame to have a duration of a second from the perspective
+of a Swadge mode. Because the number of actual frames per second doesn't change, this means that 60 seconds
 (one simulated second per actual frame) will appear to pass every second.
 
 `--fake-time`: Use a simulated timer that ticks at a constant rate every frame. If used with `--fake-fps`,
 the fake frame rate and fake time will be aligned. This argument can be useful when recording or replaying
 inputs to ensure that slight differences in frame timing do not cause inconsistencies.
 
-`--lock`: Locks the swadge mode to the starting mode. This prevents all normal means of changing swadge
+`--lock`: Locks the Swadge mode to the starting mode. This prevents all normal means of changing Swadge
 modes. The mode can still be changed automatically by `--mode-switch`, the console, and by a `SetMode'
 command when replaying recorded inputs.
 
@@ -332,18 +332,18 @@ type `help <command>` into the console.
 If the emulator opens to the factory test mode instead of either the main menu or the tutorial mode, this
 is because it is unable to write to the `nvs.json` file in the current directory.
 
+Try moving the swadge-emulator to a new folder where it will have permission to write.
 
 ## Simulated ESPNOW Networking
 
-The Swadge Emulator is capable of simulating the wireless ESPNOW connection between two swadges. This
-functionality is enabled automatically by simply running two swadge emulator programs at the same time.
+The Swadge Emulator is capable of simulating the wireless ESPNOW connection between two Swadges. This
+functionality is enabled automatically by simply running two Swadge emulator programs at the same time.
 For best results, you should start each Swadge Emulator from a different directory, to avoid potential
 corruption caused by two instances attempting to save data to the same `nvs.json` file at the same time.
 
 **Note**: This functionality only supports local connections between two Swadge Emulators running on the
 same machine. Networking between Swadge Emulators running on different machines is not supported at this
 time.
-
 
 ## MIDI Instructions
 

--- a/docs/SERIAL_DEBUG.md
+++ b/docs/SERIAL_DEBUG.md
@@ -169,7 +169,7 @@ I (692) gpio: GPIO[5]| InputEn: 1| OutputEn: 0| OpenDrain: 0| Pullup: 1| Pulldow
 I (752) gpio: GPIO[21]| InputEn: 0| OutputEn: 1| OpenDrain: 0| Pullup: 0| Pulldown: 0| Intr:0
 I (752) gpio: GPIO[38]| InputEn: 0| OutputEn: 1| OpenDrain: 0| Pullup: 0| Pulldown: 0| Intr:0
 ```
-To figure out where your last crash was, xecute the `xtensa-esp32s2-elf-addr2line` line as it appears in the log. I.e.
+To figure out where your last crash was, execute the `xtensa-esp32s2-elf-addr2line` line as it appears in the log. I.e.
 
 ```bash
 $ xtensa-esp32s2-elf-addr2line -e build/swadge2024.elf 0x4008aab0:0x00060930

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -166,11 +166,14 @@ When launching from VS Code, make sure the `(lldb) Launch` configuration is sele
 
 ## Configuring VSCode
 
-[Visual Studio Code IDE](https://code.visualstudio.com/) is recommended for all OSes. The following plugins are recommended:
+[Visual Studio Code IDE](https://code.visualstudio.com/) is recommended for all OSes. The following plugins are **REQUIRED**:
 * [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) - Basic support
+  - For MacOS, [LLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) is used instead
 * [C/C++ Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools-extension-pack) - Basic support
 * [Makefile Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.makefile-tools) - Basic support
 * [Espressif IDF](https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-extension) - Integration with ESP-IDF. When setting this up for the first time, point it at ESP-IDF which was previously installed. Do not let it install a second copy. Remember that ESP-IDF should exist in `~/esp/esp-idf` and the tools should exist in `~/.espressif/`.
+
+While not 100% required, these extensions are highly recommended:
 * [C/C++ Advanced Lint](https://marketplace.visualstudio.com/items?itemName=jbenden.c-cpp-flylint) - Integration with `cppcheck`
 * [Clang-Format](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format) - Integration with `clang-format`
 * [Doxygen Documentation Generator](https://marketplace.visualstudio.com/items?itemName=cschlosser.doxdocgen) - Integration with `doxygen`

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -176,8 +176,12 @@ When launching from VS Code, make sure the `(lldb) Launch` configuration is sele
 While not 100% required, these extensions are highly recommended:
 * [C/C++ Advanced Lint](https://marketplace.visualstudio.com/items?itemName=jbenden.c-cpp-flylint) - Integration with `cppcheck`
 * [Clang-Format](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format) - Integration with `clang-format`
+* [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) - Helps minimize typos
 * [Doxygen Documentation Generator](https://marketplace.visualstudio.com/items?itemName=cschlosser.doxdocgen) - Integration with `doxygen`
+* [Github Actions](https://marketplace.visualstudio.com/items?itemName=github.vscode-github-actions) - GUI for git interactions
 * [Todo Tree](https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree) - Handy to track "to-do items"
+
+All of the extensions listed above are in the "recommended" tab of VS Code when this repository is active.
 
 The `.vscode` folder already has tasks for making and cleaning the emulator. It also has launch settings for launching the emulator with `gdb` attached. To build the firmware from VSCode, use the Espressif extension buttons on the bottom toolbar. The build icon looks like a cylinder. Hover over the other icons to see what they do.
 

--- a/emulator/README.md
+++ b/emulator/README.md
@@ -7,3 +7,5 @@ The Emulator does not require the ESP-IDF, and instead the files required for co
 The [`./src/idf`](./src/idf/) folder reimplements a few parts of the IDF. For the most part the Emulator strives to reimplement components rather than parts of the IDF.
 
 The [`./src/components`](./src/components) folder reimplements this project's [`../components`](../components/) folder, which has the hardware interfaces for ESP32-S2. The Emulator is compiled with the header files from the main [`../components`](../components/) folder for consistency.
+
+Read [the documentation](./../docs/EMULATOR.md) for usage.

--- a/main/swadge2024.c
+++ b/main/swadge2024.c
@@ -4,7 +4,7 @@
  *
  * \section intro_sec Introduction
  *
- * Welcome to the Swadge 2024 API documentation! Here you will find information on how to use all hardware features of a
+ * Welcome to the Swadge API documentation! Here you will find information on how to use all hardware features of a
  * Swadge and write a Swadge mode. A Swadge is <a href="https://www.magfest.org/">Magfest's</a> electronic swag-badges.
  * They play games and make music and shine bright and do all sorts of cool things.
  *
@@ -20,7 +20,7 @@
  * contributing to this project, email circuitboards@magfest.org.
  *
  * General Swadge design principles <a
- * href="https://docs.google.com/document/d/1TzzatyRWp9t26YWF3qUlOg7NFgmsueL-0suqyDT98IE/edit">can be found here</a>.
+ * href="https://github.com/AEFeinstein/Super-2024-Swadge-FW/blob/main/docs/DESIGN_PRINCIPLES.md">can be found here</a>.
  *
  * \section start Where to Start
  *

--- a/main/swadge2024.c
+++ b/main/swadge2024.c
@@ -20,7 +20,7 @@
  * contributing to this project, email circuitboards@magfest.org.
  *
  * General Swadge design principles <a
- * href="https://github.com/AEFeinstein/Super-2024-Swadge-FW/blob/main/docs/DESIGN_PRINCIPLES.md">can be found here</a>.
+ * href="/docs/DESIGN_PRINCIPLES.md">can be found here</a>.
  *
  * \section start Where to Start
  *


### PR DESCRIPTION
### Description

Typos and some simple fixes. Nothing major, but I did add some missing extensions and split them into necessary/unnecessary sections.
