### PR TITLE
Added usernamer to swadgePass

### DIFF
--- a/main/utils/nameList.c
+++ b/main/utils/nameList.c
@@ -152,8 +152,8 @@ void initUsernameSystem()
 
     // Initialize
     swadgeUsername.user = true;
-    size_t blobLen = 3 * sizeof(int8_t);
-    if(!readNvsBlob(nvsKeys, &swadgeUsername.idxs, &blobLen))
+    size_t blobLen      = 3 * sizeof(int8_t);
+    if (!readNvsBlob(nvsKeys, &swadgeUsername.idxs, &blobLen))
     {
         generateMACUsername(&swadgeUsername);
         writeNvsBlob(nvsKeys, swadgeUsername.idxs, 3 * sizeof(int8_t));

--- a/main/utils/nameList.c
+++ b/main/utils/nameList.c
@@ -67,6 +67,8 @@ static const char* const nounList[] = {
     "woodwind", "drummer",  "rocker",   "wolf",    "snake",    "driver",  "seahorse", "artist", "foxbat",  "eagle",
 };
 
+static const char nvsKeys[] = "username";
+
 //==============================================================================
 // Enums
 //==============================================================================
@@ -135,6 +137,7 @@ static void _drawFadingWords(nameData_t* nd);
 static uint8_t baseMac[6];
 static int listLen[3];
 static uint8_t mutatorSeeds[3];
+nameData_t swadgeUsername;
 
 //==============================================================================
 // Functions
@@ -146,6 +149,16 @@ void initUsernameSystem()
     listLen[1] = ARRAY_SIZE(adjList2);
     listLen[2] = ARRAY_SIZE(nounList);
     _getMacAddress();
+
+    // Initialize
+    swadgeUsername.user = true;
+    size_t blobLen = 3 * sizeof(int8_t);
+    if(!readNvsBlob(nvsKeys, &swadgeUsername.idxs, &blobLen))
+    {
+        generateMACUsername(&swadgeUsername);
+        writeNvsBlob(nvsKeys, swadgeUsername.idxs, 3 * sizeof(int8_t));
+    }
+    setUsernameFromND(&swadgeUsername);
 }
 
 void generateMACUsername(nameData_t* nd)
@@ -483,4 +496,9 @@ static void _drawFadingWords(nameData_t* nd)
             }
         }
     }
+}
+
+nameData_t* getSystemUsername(void)
+{
+    return &swadgeUsername;
 }

--- a/main/utils/nameList.h
+++ b/main/utils/nameList.h
@@ -94,3 +94,10 @@ bool handleUsernamePickerInput(buttonEvt_t* evt, nameData_t* nd);
  * @param nd The data
  */
 void drawUsernamePicker(nameData_t* nd);
+
+/**
+ * @brief Get the System Username object
+ * 
+ * @return nameData_t* The username for the system at large
+ */
+nameData_t* getSystemUsername(void);

--- a/main/utils/nameList.h
+++ b/main/utils/nameList.h
@@ -97,7 +97,7 @@ void drawUsernamePicker(nameData_t* nd);
 
 /**
  * @brief Get the System Username object
- * 
+ *
  * @return nameData_t* The username for the system at large
  */
 nameData_t* getSystemUsername(void);

--- a/main/utils/swadgePass.c
+++ b/main/utils/swadgePass.c
@@ -50,12 +50,11 @@ void fillSwadgePassPacket(swadgePassPacket_t* packet)
 
     // Automatically fill in username
     nameData_t* user = getSystemUsername();
-    for(int i = 0; i < 3; i++)
+    for (int i = 0; i < 3; i++)
     {
         packet->username.nameIdxs[i] = user->idxs[i];
     }
     packet->username.nameIdxs[3] = user->randCode;
-    
 
     // Ask each mode to fill in the rest
     int modeCount = modeListGetCount();

--- a/main/utils/swadgePass.c
+++ b/main/utils/swadgePass.c
@@ -6,6 +6,7 @@
 #include <hdw-nvs.h>
 #include "swadgePass.h"
 #include "modeIncludeList.h"
+#include "nameList.h"
 
 //==============================================================================
 // Defines
@@ -46,6 +47,15 @@ void fillSwadgePassPacket(swadgePassPacket_t* packet)
     // Set the preamble
     packet->preamble = SWADGE_PASS_PREAMBLE;
     packet->version  = SWADGE_PASS_VERSION;
+
+    // Automatically fill in username
+    nameData_t* user = getSystemUsername();
+    for(int i = 0; i < 3; i++)
+    {
+        packet->username.nameIdxs[i] = user->idxs[i];
+    }
+    packet->username.nameIdxs[3] = user->randCode;
+    
 
     // Ask each mode to fill in the rest
     int modeCount = modeListGetCount();

--- a/main/utils/swadgePass.h
+++ b/main/utils/swadgePass.h
@@ -120,7 +120,7 @@ typedef struct __attribute__((packed)) swadgePassPacket
 {
     uint16_t preamble; ///< Two bytes that specifically begin a SwadgePass packet
     uint8_t version;   ///< A version byte to differentiate packets per-year
-    struct 
+    struct
     {
         uint8_t nameIdxs[4];
     } username;

--- a/main/utils/swadgePass.h
+++ b/main/utils/swadgePass.h
@@ -120,6 +120,10 @@ typedef struct __attribute__((packed)) swadgePassPacket
 {
     uint16_t preamble; ///< Two bytes that specifically begin a SwadgePass packet
     uint8_t version;   ///< A version byte to differentiate packets per-year
+    struct 
+    {
+        uint8_t nameIdxs[4];
+    } username;
     struct
     {
         int8_t reactHs;


### PR DESCRIPTION
## Description

Adds the username to the swadgepass struct

## Test Instructions

Verified saved username was sent to another swadge in the emulator (checked nvs.json)

## Ticket Links

None

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
