### PR TITLE
Actually changing the username for setUsernameFrom32()

### DIFF
--- a/main/utils/nameList.c
+++ b/main/utils/nameList.c
@@ -394,6 +394,7 @@ void setUsernameFrom32(nameData_t* nd, int32_t packed)
     nd->idxs[1]  = (packed >> 16) & 0xFF;
     nd->idxs[2]  = (packed >> 8) & 0xFF;
     nd->randCode = packed & 0xFF;
+    setUsernameFromND(nd);
 }
 
 //==============================================================================


### PR DESCRIPTION
## Description

Added `setUsernameFromND(nd);`` to `setUsernameFrom32()`

## Test Instructions

Check second line in name test mode terminal print in not identical to first line.

## Ticket Links

None

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
