### PR TITLE
Fix incorrect loop point in MMX vibraphone

### DIFF
--- a/main/midi/midiData.c
+++ b/main/midi/midiData.c
@@ -307,7 +307,7 @@ const midiTimbre_t mmx011Vibraphone = {
         .loop = 0,
         // 28928 Hz original file
         .loopStart = SAMPLE_NUM_CONV(79, 28928, 16384),
-        .loopEnd = SAMPLE_NUM_CONV(79, 28928, 16384),
+        .loopEnd = SAMPLE_NUM_CONV(95, 28928, 16384),
         // But we convert it to avoid resampling
         .rate = 16384,
         // pitch keycenter=82, plus tune=50


### PR DESCRIPTION
## Description

Changes the loop point for the MMX vibraphone so it's not wrong!

## Test Instructions

Build the emulator and listen to the MMX vibraphone. It actually plays more than a click now!!!

## Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [ ] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated
