### PR TITLE
Swadgetamatone trophies and tweaks

### DIFF
--- a/main/modes/system/mainMenu/mainMenu.c
+++ b/main/modes/system/mainMenu/mainMenu.c
@@ -136,6 +136,15 @@ const trophyData_t mainMenuTrophies[] = {
         .identifier  = &synthMode,
     },
     {
+        .title       = "The song of my people",
+        .description = "Opened Swadgetamatone for the first time",
+        .image       = NO_IMAGE_SET,
+        .type        = TROPHY_TYPE_TRIGGER,
+        .difficulty  = TROPHY_DIFF_EASY,
+        .maxVal      = 1,
+        .identifier  = &swadgetamatoneMode,
+    },
+    {
         .title       = "Blinded by the lights",
         .description = "Opened Light dances on purpose for the first time",
         .image       = NO_IMAGE_SET,


### PR DESCRIPTION
## Description

- Add a fourth octave and simplify octave logic
- Only open mouth when playing notes
- Animate mouth open/close when a note starts/stops
- Trophies!

## Test Instructions

1. Run the mode. Ensure the main menu trophy is granted.
2. Play a note. Ensure the first mode trophy is granted.
3. Play notes for at least 60 seconds to ensure the timed trophies work.
4. Play for another hour and ensure the other 2 timed trophies work if you want to be really thorough.
5. Test all of the d-pad buttons to ensure they all play different octaves.

## Ticket Links

https://github.com/AEFeinstein/Super-2024-Swadge-FW/issues/483

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [x] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [x] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated
