### PR TITLE
Fixed includeList.c/.h location

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -417,11 +417,11 @@ If all else fails, try searching the error message on the internet, or contact t
 
 Now, we're going to have to modify a few other files. Fortunately, only two more for now.
 
-First up, we need to tell the other modes about our mode. Open `main/modeIncludeList.h` and add our header file to the list of includes.
+First up, we need to tell the other modes about our mode. Open `main/utils/menu/modeIncludeList.h` and add our header file to the list of includes.
 
 ![Include List](./TutorialImages/includeList.png)
 
-Next, open `main/modeIncludeList.c` and add the following:
+Next, open `main/utils/menu/modeIncludeList.c` and add the following:
 
 - Inside the `allSwadgeModes[]` list, add `&roboRunnerMode,` at the end of the list before the end curly brace.
 - Add `addSingleItemToMenu(menu, roboRunnerMode.modeName);` inside one of the submenus. Whichever submenu you put this in is where it'll be in the main menu. It's best to put games in the games section, obviously.


### PR DESCRIPTION
## Description

Fixes for the new modeIncludeList.c/.h locations

## Test Instructions
Looked at docs

## Ticket Links

None.

## Readiness Checklist

### Code Quality

- [ ] I have run `make format` to format the changes
- [ ] I have compiled the firmware and the changes have no warnings
- [ ] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [ ] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated
